### PR TITLE
Add animated SignUpFlowCard and update landing page content and copy

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -4,12 +4,27 @@ function usePrefersReducedMotion() {
   const [prefersReducedMotion, setPrefersReducedMotion] = useState(false);
 
   useEffect(() => {
+    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+      setPrefersReducedMotion(false);
+      return undefined;
+    }
+
     const mediaQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
-    setPrefersReducedMotion(mediaQuery.matches);
+    setPrefersReducedMotion(Boolean(mediaQuery.matches));
 
     const handleChange = (event) => setPrefersReducedMotion(event.matches);
-    mediaQuery.addEventListener('change', handleChange);
-    return () => mediaQuery.removeEventListener('change', handleChange);
+
+    if (typeof mediaQuery.addEventListener === 'function') {
+      mediaQuery.addEventListener('change', handleChange);
+      return () => mediaQuery.removeEventListener('change', handleChange);
+    }
+
+    if (typeof mediaQuery.addListener === 'function') {
+      mediaQuery.addListener(handleChange);
+      return () => mediaQuery.removeListener(handleChange);
+    }
+
+    return undefined;
   }, []);
 
   return prefersReducedMotion;
@@ -183,22 +198,33 @@ export default function CkConfluxLandingPage() {
 
   const learnSections = [
     {
-      title: 'Start with Element chat',
-      body: 'Use Element Web at element.ckconflux.com for messaging, rooms, spaces, file sharing, voice messages, and secure direct chats. It is the easiest place for most people to begin.',
-      cta: 'Open Element Web',
+      title: 'Element on Matrix',
+      label: 'Default for most people',
+      body: 'Think Discord-style communities, channels, direct messages, and calls, but with an open Matrix account you keep. Start here for day-to-day chat and community coordination.',
+      cta: 'Start with Element Web',
       href: 'https://element.ckconflux.com',
+      secondaryCta: 'Element user guide',
+      secondaryHref: 'https://element.io/en/user-guide',
     },
     {
-      title: 'Join Mastodon for social updates',
-      body: 'Mastodon is a federated social network, similar to Twitter or Bluesky in day-to-day use, but community-run. Register on masto.colonelkrud.com to follow updates, discover people, and join conversations beyond chat rooms.',
+      title: 'Mastodon',
+      label: 'Best for social updates',
+      body: 'Mastodon is closer to Twitter or Bluesky than Discord chat. Use it for posts, discovery, and following people across many communities while keeping your home account here.',
       cta: 'Register for Mastodon',
       href: 'https://masto.colonelkrud.com/auth/sign_up',
+      secondaryCta: 'Mastodon user guide',
+      secondaryHref: 'https://docs.joinmastodon.org/user/',
+      note: 'New accounts require manual approval.',
     },
     {
-      title: 'Use TeamSpeak for voice-first sessions',
-      body: 'TeamSpeak is still one of the best tools for low-overhead voice chat for gaming and live coordination. Download the client, then connect to ts3.ckconflux.com to join the server.',
+      title: 'TeamSpeak',
+      label: 'Best for voice-first coordination',
+      body: 'If your group is voice-first, TeamSpeak is the fastest route from install to talking. It is a strong fit for gaming, raids, and live ops where low latency matters.',
       cta: 'Download TeamSpeak',
       href: 'https://www.teamspeak.com/en/downloads/',
+      secondaryCta: 'TeamSpeak getting started',
+      secondaryHref: 'https://www.teamspeak.com/en/support/get-started/',
+      note: 'Server address: ts3.ckconflux.com',
     },
   ];
 
@@ -245,47 +271,91 @@ export default function CkConfluxLandingPage() {
   const faqs = [
     {
       q: 'What should I use first?',
-      a: 'Start with Element Web at element.ckconflux.com. That is the main chat experience for messaging, rooms, communities, voice, and video.',
+      a: 'Start with Element Web at element.ckconflux.com. It is the default choice for chat, DMs, communities, voice, and video.',
     },
     {
-      q: 'What is my username?',
-      a: 'Your permanent Matrix ID is called an MXID. It looks like @yourname:ckconflux.com. It does not change later, but your display name can.',
+      q: 'What is MatrixRTC / Element Call?',
+      a: 'MatrixRTC is the real-time calling tech used in Matrix. In Element, this shows up as Element Call for room-based voice and video meetings.',
     },
     {
-      q: 'Why do you ask for email verification?',
-      a: 'Email verification helps confirm that you control the account and gives you a recovery path if you lose access later.',
+      q: 'Does Element support screen sharing?',
+      a: 'Yes. Screen sharing is available in Element calls on supported platforms and browsers.',
     },
     {
-      q: 'Is this basically Discord?',
-      a: 'For most people, yes in everyday use. You still get communities, rooms, DMs, media sharing, and calls. The big difference is stronger privacy, open standards, and community ownership.',
+      q: 'Can I use different display names in different rooms?',
+      a: 'Usually you set one profile display name for your account, but some clients and room settings can show room-specific profile info. Your MXID stays the same either way.',
     },
     {
-      q: 'What is a room, space, or call room?',
-      a: 'A space is like a Discord server. A room is like a channel. A call room gives you voice or video inside the Matrix room flow instead of making voice chat feel like a separate product.',
+      q: 'How do direct messages work in Element?',
+      a: 'Use the Start Chat / New Message option, pick a user, and Element creates a private DM room between you and that person.',
     },
     {
-      q: 'Can I discover communities outside this server?',
-      a: 'Yes. Matrix lets you join public rooms and spaces from other servers, so your account on ckconflux.com can still participate across the wider network.',
+      q: 'How do I invite friends with registration codes?',
+      a: 'Share a registration code from an existing member with your friend, then they use it during account creation on element.ckconflux.com.',
     },
     {
-      q: 'How do I join Mastodon here?',
-      a: 'Go to masto.colonelkrud.com and register for an account. Accounts are manually approved so expect a review step before access is granted.',
-    },
-    {
-      q: 'How do I join TeamSpeak?',
-      a: 'Install the TeamSpeak client, open it, choose to connect to a server, and enter ts3.ckconflux.com as the server address.',
+      q: 'Can registration codes be revoked?',
+      a: 'Yes. Registration codes are access controls and can be revoked if abused, spammed, or shared in bad faith.',
     },
     {
       q: 'How do I get a registration token?',
       a: 'New Matrix accounts need a registration token. You can request one from an existing member, or get token access through any supported tier at buymeacoffee.com/conflux.',
     },
     {
+      q: 'Can I discover communities outside this server?',
+      a: 'Yes. Your ckconflux.com account can join public Matrix rooms and spaces hosted on other servers.',
+    },
+    {
+      q: 'Can I use another Matrix client besides Element?',
+      a: 'Yes. You are not locked to one app. Popular options include Element X (iOS/Android), Nheko (Windows/macOS/Linux), Element Web/Desktop (Web/Windows/macOS/Linux), FluffyChat (iOS/Android/Linux/Web), and Cinny (Web with desktop packaging available).',
+    },
+    {
+      q: 'What mobile apps can I use for Element?',
+      a: 'Element has official mobile apps for iOS and Android, and your same account can also be used in compatible Matrix clients.',
+    },
+    {
+      q: 'What mobile apps can I use for Mastodon?',
+      a: 'You can use the official Mastodon app on iOS and Android, or other compatible Mastodon apps if you prefer.',
+    },
+    {
+      q: 'Is there a mobile app for TeamSpeak?',
+      a: 'Yes. TeamSpeak offers mobile clients, and you can still use desktop clients for longer sessions.',
+    },
+    {
+      q: 'TeamSpeak 6 vs TeamSpeak 3: which should I use?',
+      a: 'Use whichever client works best for your setup. Both are common in the community, so choose based on stability and features you prefer.',
+    },
+    {
+      q: 'How do I report content in Mastodon?',
+      a: 'Open the post or account menu and use Report. Include context so moderators can review quickly.',
+    },
+    {
+      q: 'How do I report content in Element?',
+      a: 'Use the message or user actions menu in Element and choose Report. If needed, also contact server moderators with room links and timestamps.',
+    },
+    {
+      q: 'How do I report content in TeamSpeak?',
+      a: 'Report the issue to server admins or moderators with usernames, channel details, and time of incident.',
+    },
+    {
+      q: 'How do I ignore users in Element?',
+      a: 'Open the user profile and add them to your ignore list. This hides messages and reduces unwanted contact.',
+    },
+    {
+      q: 'How do I ignore users in Mastodon?',
+      a: 'Use Mute for a softer filter or Block for a stronger stop. Both options are available from a user profile menu.',
+    },
+    {
+      q: 'How do notification settings work in Element?',
+      a: 'You can tune notifications globally and per room, including mute, mentions-only, and custom alert rules.',
+    },
+    {
       q: 'Do files stay forever?',
-      a: 'You can send images and files just like Discord. If a file is accessed regularly, it stays available. If no one views it for over a year, it is automatically removed. We used to store files forever, but storage costs became too high to sustain long term.',
+      a: 'You can send images and files like Discord. If a file is accessed regularly, it stays available. If no one views it for over a year, it is automatically removed.',
     },
     {
       q: 'How is moderation handled?',
-      a: 'Moderation is best effort. CK Conflux uses Draupnir for community moderation, which is part of the Matrix moderation ecosystem and helps with coordinated, shared protections across rooms and communities. We also participate in the Mastodon Garden Fence Project blocklist ecosystem. The goal is to reduce abuse, spam, and harmful content, but moderation is never perfect.',
+      a: 'Moderation is best effort. CK Conflux uses Draupnir for community moderation and participates in the Garden Fence blocklist ecosystem to reduce abuse, spam, and harmful content.',
     },
   ];
 
@@ -519,56 +589,29 @@ export default function CkConfluxLandingPage() {
             <div className="max-w-3xl">
               <p className="text-sm font-semibold uppercase tracking-[0.2em] text-cyan-200">Get started by service</p>
               <h2 className="mt-3 text-3xl font-semibold tracking-tight text-white sm:text-4xl">Choose the tool that matches how you want to connect</h2>
-              <p className="mt-4 text-lg leading-8 text-slate-300">Chat, social posting, and voice each have a different job. The easiest acquisition path is to explain the benefit first, then the next action.</p>
             </div>
             <div className="mt-10 grid gap-6 lg:grid-cols-3">
               {learnSections.map((section) => (
-                <a
+                <div
                   key={section.title}
-                  href={section.href}
                   className="group block rounded-[1.75rem] border border-white/10 bg-white/5 p-6 shadow-lg shadow-black/20 transition hover:-translate-y-1 hover:border-cyan-300/30 hover:bg-white/[0.07]"
                 >
+                  <div className="text-xs font-semibold uppercase tracking-[0.16em] text-cyan-200">{section.label}</div>
                   <h3 className="text-xl font-semibold text-white">{section.title}</h3>
                   <p className="mt-3 leading-7 text-slate-300">{section.body}</p>
-                  <div className="mt-5 inline-flex items-center gap-2 text-sm font-medium text-cyan-200">{section.cta}</div>
-                </a>
+                  {section.note && <div className="mt-4 rounded-2xl border border-amber-300/20 bg-amber-300/10 px-4 py-3 text-sm text-amber-100">{section.note}</div>}
+                  <div className="mt-5 space-y-2 text-sm text-cyan-200">
+                    <a href={section.href} className="block font-medium">
+                      {section.cta}
+                    </a>
+                    {section.secondaryCta && section.secondaryHref && (
+                      <a href={section.secondaryHref} className="block">
+                        {section.secondaryCta}
+                      </a>
+                    )}
+                  </div>
+                </div>
               ))}
-            </div>
-          </div>
-        </section>
-
-        <section className="mx-auto max-w-7xl px-6 py-16 lg:px-8">
-          <div className="grid gap-6 lg:grid-cols-3">
-            <div className="rounded-[1.75rem] border border-white/10 bg-white/5 p-6">
-              <div className="inline-flex rounded-2xl bg-cyan-400/10 p-3 text-cyan-200">•</div>
-              <h3 className="mt-5 text-xl font-semibold text-white">Element on Matrix</h3>
-              <p className="mt-3 leading-7 text-slate-300">Best for persistent chat, communities, direct messages, media sharing, spaces, voice messages, and secure collaboration. Great default choice for most users.</p>
-              <div className="mt-5 space-y-2 text-sm text-cyan-200">
-                <a href="https://element.ckconflux.com" className="block">Open Element Web</a>
-                <a href="https://element.io/en/user-guide" className="block">Element user guide</a>
-              </div>
-            </div>
-            <div className="rounded-[1.75rem] border border-white/10 bg-white/5 p-6">
-              <div className="inline-flex rounded-2xl bg-cyan-400/10 p-3 text-cyan-200">•</div>
-              <div className="mt-4 text-xs font-semibold uppercase tracking-[0.16em] text-cyan-200">Best for social updates</div>
-              <h3 className="mt-5 text-xl font-semibold text-white">Mastodon</h3>
-              <p className="mt-3 leading-7 text-slate-300">Best for public posting, following updates, and lightweight social discovery. It is a federated social network, which means you can follow people across many servers while keeping your home account here.</p>
-              <div className="mt-4 rounded-2xl border border-amber-300/20 bg-amber-300/10 px-4 py-3 text-sm text-amber-100">New accounts require manual approval.</div>
-              <div className="mt-5 space-y-2 text-sm text-cyan-200">
-                <a href="https://masto.colonelkrud.com/auth/sign_up" className="block">Register on Mastodon</a>
-                <a href="https://docs.joinmastodon.org/user/" className="block">Mastodon user guide</a>
-              </div>
-            </div>
-            <div className="rounded-[1.75rem] border border-white/10 bg-white/5 p-6">
-              <div className="inline-flex rounded-2xl bg-cyan-400/10 p-3 text-cyan-200">•</div>
-              <div className="mt-4 text-xs font-semibold uppercase tracking-[0.16em] text-cyan-200">Best for voice coordination</div>
-              <h3 className="mt-5 text-xl font-semibold text-white">TeamSpeak</h3>
-              <p className="mt-3 leading-7 text-slate-300">Best for low-latency voice sessions, gaming, and live coordination. If your group is voice-first, this is the fastest path from install to talking.</p>
-              <div className="mt-5 space-y-2 text-sm text-cyan-200">
-                <a href="https://www.teamspeak.com/en/downloads/" className="block">Download TeamSpeak</a>
-                <a href="https://www.teamspeak.com/en/support/get-started/" className="block">TeamSpeak getting started guide</a>
-                <div className="pt-1 text-slate-400">Server address: <span className="font-medium text-white">ts3.ckconflux.com</span></div>
-              </div>
             </div>
           </div>
         </section>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,3 +1,155 @@
+import { useEffect, useRef, useState } from 'react';
+
+function usePrefersReducedMotion() {
+  const [prefersReducedMotion, setPrefersReducedMotion] = useState(false);
+
+  useEffect(() => {
+    const mediaQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
+    setPrefersReducedMotion(mediaQuery.matches);
+
+    const handleChange = (event) => setPrefersReducedMotion(event.matches);
+    mediaQuery.addEventListener('change', handleChange);
+    return () => mediaQuery.removeEventListener('change', handleChange);
+  }, []);
+
+  return prefersReducedMotion;
+}
+
+const signUpFields = [
+  { key: 'username', label: 'Choose a username', value: '@yourname:ckconflux.com', helper: 'This becomes your permanent Matrix ID, also called your MXID. Your display name can change later, but your MXID does not.' },
+  { key: 'password', label: 'Create a safe password', value: 'correct-horse-battery-lantern', helper: 'Use a long passphrase that is easy for you to remember. We require a strong-but-usable password score.' },
+  { key: 'email', label: 'Add your email', value: '[email protected]', helper: 'Used for verification and account recovery.' },
+];
+
+export function SignUpFlowCard() {
+  const prefersReducedMotion = usePrefersReducedMotion();
+  const cardRef = useRef(null);
+  const [hasEnteredView, setHasEnteredView] = useState(false);
+  const [visibleFields, setVisibleFields] = useState(0);
+  const [typedValues, setTypedValues] = useState({ username: '', password: '', email: '' });
+  const [captchaChecked, setCaptchaChecked] = useState(false);
+
+  useEffect(() => {
+    if (!cardRef.current || hasEnteredView) {
+      return undefined;
+    }
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          setHasEnteredView(true);
+          observer.disconnect();
+        }
+      },
+      { threshold: 0.35 }
+    );
+
+    observer.observe(cardRef.current);
+    return () => observer.disconnect();
+  }, [hasEnteredView]);
+
+  useEffect(() => {
+    if (!hasEnteredView) {
+      return undefined;
+    }
+
+    if (prefersReducedMotion) {
+      setVisibleFields(signUpFields.length + 1);
+      setTypedValues({
+        username: signUpFields[0].value,
+        password: signUpFields[1].value,
+        email: signUpFields[2].value,
+      });
+      setCaptchaChecked(true);
+      return undefined;
+    }
+
+    let cancelled = false;
+    const timers = [];
+
+    const wait = (ms) =>
+      new Promise((resolve) => {
+        const id = setTimeout(resolve, ms);
+        timers.push(id);
+      });
+
+    const runSequence = async () => {
+      await wait(350);
+      for (let i = 0; i < signUpFields.length; i += 1) {
+        const field = signUpFields[i];
+        setVisibleFields(i + 1);
+        await wait(250);
+        for (let charIndex = 1; charIndex <= field.value.length; charIndex += 1) {
+          if (cancelled) {
+            return;
+          }
+          const partialValue = field.value.slice(0, charIndex);
+          setTypedValues((prev) => ({ ...prev, [field.key]: partialValue }));
+          await wait(38);
+        }
+        await wait(700);
+      }
+
+      setVisibleFields(signUpFields.length + 1);
+      await wait(900);
+      setCaptchaChecked(true);
+    };
+
+    runSequence();
+
+    return () => {
+      cancelled = true;
+      timers.forEach((timer) => clearTimeout(timer));
+    };
+  }, [hasEnteredView, prefersReducedMotion]);
+
+  return (
+    <div ref={cardRef} className="rounded-[1.8rem] border border-cyan-300/20 bg-slate-900/90 p-6 shadow-2xl shadow-cyan-950/30">
+      <div className="text-sm font-semibold uppercase tracking-[0.18em] text-cyan-200">Simple, secure sign up</div>
+      <h3 className="mt-3 text-2xl font-semibold text-white">matrix auth</h3>
+      <div className="mt-6 space-y-4">
+        {signUpFields.map((field, index) => {
+          const isVisible = visibleFields > index;
+          const value = typedValues[field.key];
+          return (
+            <div key={field.key} className={`rounded-2xl border border-white/10 bg-white/[0.04] p-4 transition duration-500 ${isVisible ? 'opacity-100' : 'opacity-0'}`}>
+              <div className="text-sm font-medium text-slate-300">{field.label}</div>
+              <div className="mt-2 flex h-11 items-center rounded-xl border border-white/10 bg-slate-950 px-3 font-mono text-sm text-slate-100">
+                {value}
+                {isVisible && value.length < field.value.length && <span className="ml-0.5 inline-block h-4 w-px animate-pulse bg-cyan-200" />}
+              </div>
+              <p className="mt-3 text-sm leading-6 text-slate-400">{field.helper}</p>
+            </div>
+          );
+        })}
+
+        <div className={`rounded-2xl border border-white/10 bg-white/[0.04] p-4 transition duration-500 ${visibleFields > signUpFields.length ? 'opacity-100' : 'opacity-0'}`}>
+          <div className="text-sm font-medium text-slate-300">Complete CAPTCHA</div>
+          <div className="mt-2 rounded-xl border border-white/15 bg-slate-950/90 p-3">
+            <div className="flex items-center justify-between gap-4">
+              <div className="flex items-center gap-3">
+                <div className={`flex h-6 w-6 items-center justify-center rounded border text-sm transition ${captchaChecked ? 'border-emerald-400 bg-emerald-500/20 text-emerald-300' : 'border-slate-500 bg-slate-800 text-transparent'}`}>
+                  ✓
+                </div>
+                <span className="text-sm text-slate-100">I am human</span>
+              </div>
+              <div className="rounded-md border border-white/10 bg-white/[0.03] px-2 py-1 text-[10px] uppercase tracking-[0.16em] text-slate-400">CAPTCHA</div>
+            </div>
+          </div>
+          <p className="mt-3 text-sm leading-6 text-slate-400">This helps keep bots and spam out.</p>
+        </div>
+      </div>
+      <p className="mt-5 text-sm leading-6 text-slate-300">After that, verify your email and continue into Element Web.</p>
+      <a
+        href="https://buymeacoffee.com/conflux"
+        className="mt-4 inline-flex rounded-xl bg-amber-300 px-4 py-2 text-sm font-semibold text-slate-950 transition hover:-translate-y-0.5"
+      >
+        Get a registration token
+      </a>
+    </div>
+  );
+}
+
 export default function CkConfluxLandingPage() {
   const matrixFeatures = [
     {
@@ -124,8 +276,8 @@ export default function CkConfluxLandingPage() {
       a: 'Install the TeamSpeak client, open it, choose to connect to a server, and enter ts3.ckconflux.com as the server address.',
     },
     {
-      q: 'How do I find and join rooms?',
-      a: 'You can browse public rooms using https://matrixrooms.info/, a directory that lets you search communities by topic or interest. There are thousands of rooms across many servers. You can join existing communities or create your own with friends. Some large rooms require approval to join. If a room has more than 1,000 members, you may receive a direct message with instructions after requesting access.',
+      q: 'How do I get a registration token?',
+      a: 'New Matrix accounts need a registration token. You can request one from an existing member, or get token access through any supported tier at buymeacoffee.com/conflux.',
     },
     {
       q: 'Do files stay forever?',
@@ -133,7 +285,7 @@ export default function CkConfluxLandingPage() {
     },
     {
       q: 'How is moderation handled?',
-      a: 'Moderation is best effort and community driven. We work to keep the space healthy, but this is not a giant corporate platform with a massive trust and safety department.',
+      a: 'Moderation is best effort. CK Conflux uses Draupnir for community moderation, which is part of the Matrix moderation ecosystem and helps with coordinated, shared protections across rooms and communities. We also participate in the Mastodon Garden Fence Project blocklist ecosystem. The goal is to reduce abuse, spam, and harmful content, but moderation is never perfect.',
     },
   ];
 
@@ -193,6 +345,7 @@ export default function CkConfluxLandingPage() {
                   See the sign-up steps
                 </a>
               </div>
+              <p className="mt-3 text-sm text-slate-400">No ads. Community-run since 2015.</p>
               <div className="mt-8 grid gap-4 sm:grid-cols-3">
                 <div className="rounded-2xl border border-white/10 bg-white/5 p-4">
                   <div className="text-sm text-slate-400">Chat identity</div>
@@ -257,6 +410,38 @@ export default function CkConfluxLandingPage() {
           </div>
         </section>
 
+        <section id="signin" className="mx-auto max-w-7xl px-6 py-16 lg:px-8">
+          <div className="grid gap-10 lg:grid-cols-[0.95fr_1.05fr] lg:items-start">
+            <div>
+              <p className="text-sm font-semibold uppercase tracking-[0.2em] text-cyan-200">How to sign in</p>
+              <h2 className="mt-3 text-3xl font-semibold tracking-tight text-white sm:text-4xl">Getting started should feel simple, not confusing.</h2>
+              <p className="mt-4 text-lg leading-8 text-slate-300">We guide you through creating your account step by step so you can see exactly what to expect before you begin.</p>
+              <div className="mt-8 space-y-4">
+                {[
+                  'Choose a username first. It becomes your permanent Matrix ID (MXID).',
+                  'Use a long passphrase for a strong-but-usable password score.',
+                  'Add your email for verification and account recovery.',
+                  'Complete the CAPTCHA to reduce bots and spam.',
+                  'Verify your email, then continue into Element Web.',
+                ].map((item) => (
+                  <div key={item} className="flex items-start gap-3 rounded-2xl border border-white/10 bg-white/5 p-4">
+                    <span className="mt-0.5 h-5 w-5 flex-none text-cyan-200">•</span>
+                    <p className="text-slate-300">{item}</p>
+                  </div>
+                ))}
+              </div>
+              <div className="mt-5 rounded-2xl border border-amber-300/30 bg-amber-300/10 p-4 text-sm leading-6 text-amber-100">
+                New Matrix accounts require a registration token. Existing members can share one, and every supported tier on{' '}
+                <a href="https://buymeacoffee.com/conflux" className="font-semibold underline decoration-amber-200/70 underline-offset-2">
+                  Buy Me a Coffee
+                </a>{' '}
+                includes registration-token access.
+              </div>
+            </div>
+            <SignUpFlowCard />
+          </div>
+        </section>
+
         <section id="spaces" className="mx-auto max-w-7xl px-6 py-16 lg:px-8">
           <div className="max-w-3xl">
             <p className="text-sm font-semibold uppercase tracking-[0.2em] text-cyan-200">Spaces, rooms, and calls</p>
@@ -302,37 +487,27 @@ export default function CkConfluxLandingPage() {
             <div className="rounded-[1.75rem] border border-white/10 bg-slate-900/80 p-6">
               <div className="text-sm font-semibold uppercase tracking-[0.18em] text-cyan-200">Discovery</div>
               <h3 className="mt-3 text-2xl font-semibold text-white">Find rooms and communities beyond one server</h3>
-              <p className="mt-3 leading-7 text-slate-300">This is one of Matrix’s biggest differences from Discord. Your account can live on ckconflux.com while you still browse and join public rooms from other servers.</p>
+              <p className="mt-3 leading-7 text-slate-300">This is one of Matrix’s biggest differences from Discord. Your ckconflux.com account can still join public rooms and communities hosted on other Matrix servers.</p>
               <div className="mt-5 flex flex-wrap gap-2">
                 {publicRoomExamples.map((room) => (
                   <span key={room} className="rounded-full border border-white/10 bg-white/[0.06] px-3 py-1.5 text-sm text-slate-300">{room}</span>
                 ))}
               </div>
-              <div className="mt-5 rounded-2xl border border-white/10 bg-white/[0.04] p-4 text-sm leading-6 text-slate-400">You can also create your own room, choose whether it is public or private, and add it to a space just like building out channels in a Discord server.</div>
-            </div>
-            <div />
-          </div>
-        </section>
-
-        <section id="signin" className="mx-auto max-w-7xl px-6 py-16 lg:px-8">
-          <div className="grid gap-10 lg:grid-cols-[0.95fr_1.05fr] lg:items-start">
-            <div>
-              <p className="text-sm font-semibold uppercase tracking-[0.2em] text-cyan-200">How to sign in</p>
-              <h2 className="mt-3 text-3xl font-semibold tracking-tight text-white sm:text-4xl">Getting started should feel simple, not confusing.</h2>
-              <p className="mt-4 text-lg leading-8 text-slate-300">We guide you through creating your account step by step — username, email, password, and a quick verification. Each step is explained clearly so you know exactly what’s happening and why.</p>
-              <div className="mt-8 space-y-4">
-                {[
-                  'Pick a username. This becomes your permanent Matrix ID, also called your MXID.',
-                  'Use a long passphrase as your password. Long and memorable is safer than short and tricky.',
-                  'Complete the CAPTCHA to stop bots and spam signups.',
-                  'Verify your email so you can confirm the account and recover it later.',
-                  'Then open Element and start chatting with your new @user:ckconflux.com identity.',
-                ].map((item) => (
-                  <div key={item} className="flex items-start gap-3 rounded-2xl border border-white/10 bg-white/5 p-4">
-                    <span className="mt-0.5 h-5 w-5 flex-none text-cyan-200">•</span>
-                    <p className="text-slate-300">{item}</p>
-                  </div>
-                ))}
+              <div className="mt-5 space-y-3 rounded-2xl border border-white/10 bg-white/[0.04] p-4 text-sm leading-6 text-slate-400">
+                <p>
+                  Browse public rooms with{' '}
+                  <a href="https://matrixrooms.info/" className="font-medium text-cyan-200 underline decoration-cyan-300/60 underline-offset-2">
+                    matrixrooms.info
+                  </a>
+                  , then join what fits your interests.
+                </p>
+                <p>Create your own room, choose public or private visibility, and organize rooms into spaces just like channels under a server.</p>
+                <p>
+                  Try this room first:{' '}
+                  <a href="https://matrix.to/#/%23draupnir:matrix.org" className="font-medium text-cyan-200 underline decoration-cyan-300/60 underline-offset-2">
+                    #draupnir:matrix.org
+                  </a>
+                </p>
               </div>
             </div>
             <div />
@@ -375,6 +550,7 @@ export default function CkConfluxLandingPage() {
             </div>
             <div className="rounded-[1.75rem] border border-white/10 bg-white/5 p-6">
               <div className="inline-flex rounded-2xl bg-cyan-400/10 p-3 text-cyan-200">•</div>
+              <div className="mt-4 text-xs font-semibold uppercase tracking-[0.16em] text-cyan-200">Best for social updates</div>
               <h3 className="mt-5 text-xl font-semibold text-white">Mastodon</h3>
               <p className="mt-3 leading-7 text-slate-300">Best for public posting, following updates, and lightweight social discovery. It is a federated social network, which means you can follow people across many servers while keeping your home account here.</p>
               <div className="mt-4 rounded-2xl border border-amber-300/20 bg-amber-300/10 px-4 py-3 text-sm text-amber-100">New accounts require manual approval.</div>
@@ -385,6 +561,7 @@ export default function CkConfluxLandingPage() {
             </div>
             <div className="rounded-[1.75rem] border border-white/10 bg-white/5 p-6">
               <div className="inline-flex rounded-2xl bg-cyan-400/10 p-3 text-cyan-200">•</div>
+              <div className="mt-4 text-xs font-semibold uppercase tracking-[0.16em] text-cyan-200">Best for voice coordination</div>
               <h3 className="mt-5 text-xl font-semibold text-white">TeamSpeak</h3>
               <p className="mt-3 leading-7 text-slate-300">Best for low-latency voice sessions, gaming, and live coordination. If your group is voice-first, this is the fastest path from install to talking.</p>
               <div className="mt-5 space-y-2 text-sm text-cyan-200">
@@ -421,11 +598,22 @@ export default function CkConfluxLandingPage() {
                 <p className="mt-3 max-w-2xl text-lg leading-8 text-slate-300">It’s a passion project maintained by Colonelkrud since 2015.</p>
                 <p className="mt-3 max-w-2xl text-lg leading-8 text-slate-300">We focus on reliability and transparency:</p>
                 <ul className="mt-3 list-disc space-y-2 pl-6 text-lg leading-8 text-slate-300">
-                  <li>99.999% uptime over the past year</li>
-                  <li>3 incidents totaling 3 minutes and 14 seconds</li>
+                  <li>
+                    99.999%{' '}
+                    <a href="https://status.colonelkrud.com" className="font-medium text-cyan-200 underline decoration-cyan-300/60 underline-offset-2">
+                      uptime
+                    </a>{' '}
+                    over the past year
+                  </li>
                   <li>Mean time between failures: 121.67 days</li>
                 </ul>
-                <p className="mt-3 max-w-2xl text-lg leading-8 text-slate-300">You can view uptime, maintenance, and incidents at https://status.colonelkrud.com</p>
+                <p className="mt-3 max-w-2xl text-lg leading-8 text-slate-300">
+                  Check the{' '}
+                  <a href="https://status.colonelkrud.com" className="font-medium text-cyan-200 underline decoration-cyan-300/60 underline-offset-2">
+                    status page
+                  </a>{' '}
+                  for live uptime, maintenance updates, and incident history.
+                </p>
                 <div className="mt-6 flex flex-wrap gap-3 text-sm text-cyan-200">
                   <a href="#" className="rounded-xl border border-white/10 bg-white/5 px-4 py-2">Download ToS</a>
                   <a href="#" className="rounded-xl border border-white/10 bg-white/5 px-4 py-2">Download Privacy Policy</a>

--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -19,7 +19,7 @@ describe('CK Conflux landing page', () => {
   it('renders major CTAs', () => {
     render(<App />);
     expect(screen.getByRole('link', { name: /^Start with Element$/i })).toBeInTheDocument();
-    expect(screen.getByRole('link', { name: /^Register on Mastodon$/i })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /^Register for Mastodon$/i })).toBeInTheDocument();
     expect(screen.getByRole('link', { name: /^Download TeamSpeak$/i })).toBeInTheDocument();
   });
 });

--- a/src/test-setup.js
+++ b/src/test-setup.js
@@ -1,4 +1,5 @@
 import '@testing-library/jest-dom';
+import { vi } from 'vitest';
 
 class MockIntersectionObserver {
   constructor() {}
@@ -20,4 +21,19 @@ Object.defineProperty(window, 'IntersectionObserver', {
   writable: true,
   configurable: true,
   value: MockIntersectionObserver,
+});
+
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  configurable: true,
+  value: vi.fn().mockImplementation((query) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  })),
 });


### PR DESCRIPTION
### Motivation
- Introduce a visual sign-up preview to guide new users through the Matrix onboarding steps and surface the registration-token flow.
- Improve accessibility by respecting the user's `prefers-reduced-motion` setting and providing a non-animated fallback.
- Refresh copy for discovery, moderation, and status information to be more accurate and to surface links and projects like Draupnir and the status page.
- Consolidate and simplify the sign-in / getting-started section and add calls-to-action for token access.

### Description
- Added a `usePrefersReducedMotion` hook and a new `SignUpFlowCard` React component that animates field reveal and typewriter-style example values, and falls back to an immediate state when reduced motion is preferred.
- The component uses an `IntersectionObserver` to trigger the sequence when the card enters view and cleans up timers on unmount.
- Inserted a new `#signin` section into the landing page and placed the `SignUpFlowCard` alongside updated sign-up guidance and a callout pointing to `buymeacoffee.com/conflux` for registration tokens.
- Updated multiple copy blocks and FAQ entries: changed the registration token FAQ, added moderation notes referencing Draupnir, updated discovery/help text and status links, and small UI/content tweaks (e.g. "No ads" line and short category headers for Mastodon/TeamSpeak).

### Testing
- Performed a local build and runtime check with `npm run build` and `npm start` to confirm the app compiles and the updated landing page renders without runtime errors; both succeeded.
- Ran linting (`npm run lint`) to check formatting and JSX issues; it completed successfully.
- No unit tests were added as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e07170fa58832cbc60fc580e7cf001)