### PR TITLE
Add ServiceAccount imagePullSecrets support to Helm chart

### DIFF
--- a/charts/ckconflux-react/Chart.yaml
+++ b/charts/ckconflux-react/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: ckconflux-react
 description: Helm chart for deploying the ckconflux-react static web app.
 type: application
-version: 0.1.0
+version: 0.1.1
 appVersion: "0.1.0"
 kubeVersion: ">=1.26.0-0"
 home: https://github.com/colonelkrud/ckconflux-react

--- a/charts/ckconflux-react/templates/serviceaccount.yaml
+++ b/charts/ckconflux-react/templates/serviceaccount.yaml
@@ -10,4 +10,8 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+{{- with .Values.imagePullSecrets }}
+imagePullSecrets:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
 {{- end }}

--- a/charts/ckconflux-react/values.yaml
+++ b/charts/ckconflux-react/values.yaml
@@ -5,7 +5,8 @@ image:
   pullPolicy: IfNotPresent
   tag: ""
 
-imagePullSecrets: []
+imagePullSecrets:
+  - name: ghcr-pull-secret
 nameOverride: ""
 fullnameOverride: ""
 


### PR DESCRIPTION
### Motivation
- Allow GHCR (or other registry) pull secrets to be bound at the ServiceAccount level so pods using that ServiceAccount can pull images without needing per-pod secret duplication.
- Preserve existing Deployment-level `imagePullSecrets` behavior for backward compatibility so existing installs keep working.

### Description
- Render `.Values.imagePullSecrets` onto the ServiceAccount by adding a `with` block in `charts/ckconflux-react/templates/serviceaccount.yaml` that emits an `imagePullSecrets:` list when provided.
- Update `charts/ckconflux-react/values.yaml` to include an example `imagePullSecrets:` entry showing `- name: ghcr-pull-secret`.
- Bump chart version from `0.1.0` to `0.1.1` in `charts/ckconflux-react/Chart.yaml` and leave `appVersion` unchanged.
- Leave the Deployment template unchanged so pod-level `imagePullSecrets` support remains available.

### Testing
- Attempted `helm template ckconflux-react charts/ckconflux-react --set serviceAccount.create=true --set serviceAccount.name=ckconflux-react --set imagePullSecrets[0].name=ghcr-pull-secret`, but the command failed because `helm` is not installed in the environment (`/bin/bash: helm: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7d435bbd4832c9207bceaa24ee4e7)