### PR TITLE
Make TeamSpeak server address a clickable link and update tests

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -355,7 +355,10 @@ function HomePage() {
           </article>
           <article className="rounded-2xl border border-white/10 bg-white/5 p-5">
             <h3 className="text-lg font-semibold text-white">TeamSpeak</h3>
-            <p className="mt-2 text-sm leading-6 text-slate-300">Voice-first low latency comms. Server: ts3.ckconflux.com.</p>
+            <p className="mt-2 text-sm leading-6 text-slate-300">
+              Voice-first low latency comms. Server:{' '}
+              <a className="font-semibold text-cyan-200 underline" href="ts3server://ts6.ckconflux.com">ts6.ckconflux.com</a>.
+            </p>
             <a href="https://www.teamspeak.com/en/downloads/" className="mt-4 inline-flex rounded-xl border border-white/15 bg-white/5 px-4 py-2 text-sm font-semibold text-white">Download TeamSpeak</a>
           </article>
         </div>

--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -10,6 +10,7 @@ describe('CK Conflux site IA', () => {
     render(<App />);
     expect(screen.getByRole('heading', { name: /Private community chat and calls/i })).toBeInTheDocument();
     expect(screen.getByRole('link', { name: /Open Help Center/i })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'ts6.ckconflux.com' })).toHaveAttribute('href', 'ts3server://ts6.ckconflux.com');
   });
 
   it('renders help page with policy links', () => {


### PR DESCRIPTION
### Motivation
- Expose the TeamSpeak server address as a clickable link and update the site copy to the new host `ts6.ckconflux.com` for easier discovery and launching.

### Description
- Replace the plain TeamSpeak server text with an anchor linking to `ts3server://ts6.ckconflux.com` and apply existing styling classes to the link in `src/App.jsx`.
- Update `src/App.test.jsx` to assert the presence of the `ts6.ckconflux.com` link and that it has the `href` attribute `ts3server://ts6.ckconflux.com`.

### Testing
- Ran the unit tests in `src/App.test.jsx` with `vitest`, and the updated assertions passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a87dc560578832c8f1c8188d846605c)