### PR TITLE
Add UptimeRobot status badge to site footer

### DIFF
--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -40,6 +40,18 @@ describe('CK Conflux application architecture', () => {
     expect(screen.getAllByRole('link', { name: 'Open Element' })[0]).toHaveAttribute('href', 'https://element.ckconflux.com');
   });
 
+  it('renders the independent service status badge without replacing footer navigation', () => {
+    renderPath('/');
+    const badge = screen.getByRole('img', { name: 'CK Conflux service status' });
+    expect(badge).toHaveAttribute('src', 'https://badge.uptimerobot.com/psp/177dfd29052bc6cc25407cf35076378b.svg?style=text&theme=dark');
+    expect(badge.closest('a')).toHaveAttribute('href', 'https://status.ckconflux.com?utm_source=status_badge&utm_medium=referral');
+    expect(badge.closest('a')).toHaveAttribute('target', '_blank');
+    expect(badge.closest('a')).toHaveAttribute('rel', 'noopener noreferrer');
+    expect(screen.getByRole('navigation', { name: 'Explore links' })).toHaveTextContent('Status');
+    expect(screen.getByRole('navigation', { name: 'Community links' })).toHaveTextContent('Support');
+    expect(screen.getByRole('navigation', { name: 'Legal links' })).toHaveTextContent('Privacy');
+  });
+
   it('opens and closes the accessible mobile navigation', () => {
     renderPath('/');
     const button = screen.getByRole('button', { name: 'Open navigation menu' });

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -1,5 +1,6 @@
 import { ExternalLink, SiteLink } from './SiteLink';
 import { ACCOUNT_PORTAL_URL } from '../config/community';
+import { INDEPENDENT_STATUS_BADGE_LINK, INDEPENDENT_STATUS_BADGE_URL } from '../status/status';
 const groups = [
   ['Explore', [['Membership','/membership'],['My Account',ACCOUNT_PORTAL_URL, true],['Security','/security'],['Status','/status']]],
   ['Community', [['Help','/help'],['Support','/support'],['TeamSpeak 6 Beta','/teamspeak']]],
@@ -8,7 +9,12 @@ const groups = [
 export default function Footer() {
   return <footer className="border-t border-white/10 bg-slate-950/70">
     <div className="mx-auto grid w-full max-w-6xl gap-8 px-4 py-8 sm:grid-cols-4 sm:px-6 lg:px-8">
-      <p className="text-sm text-slate-400">CK Conflux community platform</p>
+      <div>
+        <p className="text-sm text-slate-400">CK Conflux community platform</p>
+        <ExternalLink href={INDEPENDENT_STATUS_BADGE_LINK} target="_blank" rel="noopener noreferrer" className="mt-3 inline-block">
+          <img src={INDEPENDENT_STATUS_BADGE_URL} alt="CK Conflux service status" className="h-auto max-w-full" />
+        </ExternalLink>
+      </div>
       {groups.map(([heading, links]) => <nav key={heading} aria-label={`${heading} links`}><h2 className="text-sm font-semibold text-white">{heading}</h2><ul className="mt-2 space-y-2 text-sm text-slate-400">{links.map(([label,to,external]) => <li key={to}>{external ? <ExternalLink href={to} className="hover:text-white">{label}</ExternalLink> : <SiteLink to={to} className="hover:text-white">{label}</SiteLink>}</li>)}</ul></nav>)}
     </div>
   </footer>;

--- a/src/status/status.js
+++ b/src/status/status.js
@@ -12,6 +12,8 @@ const COMPONENT_ALIASES = Object.keys(COMPONENT_LABELS).sort((a, b) => b.length 
 
 export const STATUS_ENDPOINT = '/status.json';
 export const INDEPENDENT_STATUS_URL = 'https://status.ckconflux.com';
+export const INDEPENDENT_STATUS_BADGE_URL = 'https://badge.uptimerobot.com/psp/177dfd29052bc6cc25407cf35076378b.svg?style=text&theme=dark';
+export const INDEPENDENT_STATUS_BADGE_LINK = `${INDEPENDENT_STATUS_URL}?utm_source=status_badge&utm_medium=referral`;
 
 export function healthState(value) {
   const raw = typeof value === 'object' && value ? value.status ?? value.state ?? value.health ?? value.operational : value;


### PR DESCRIPTION
### Motivation
- Provide a persistent, unobtrusive link to the independently hosted CK Conflux service status by adding the official UptimeRobot badge to the site-wide footer. 
- Keep the badge implementation small and stable by centralizing the badge URLs with the existing independent-status configuration rather than scattering constants. 
- Prefer the SVG image variant for accessibility, responsiveness, and to avoid iframe embedding and sizing/CSP concerns.

### Description
- Export `INDEPENDENT_STATUS_BADGE_URL` and `INDEPENDENT_STATUS_BADGE_LINK` from `src/status/status.js`, deriving the UTM-tagged link from the existing `INDEPENDENT_STATUS_URL`. 
- Add the badge to the footer in `src/components/Footer.jsx` beneath the `CK Conflux community platform` text as an `ExternalLink` wrapping an `img` that uses the supplied dark SVG, preserves natural sizing, includes `alt="CK Conflux service status"`, and uses `target="_blank" rel="noopener noreferrer"`. 
- Add a focused RTL test in `src/App.test.jsx` asserting the badge `img` `src`, the link `href`, `target`, `rel`, the accessible name, and that existing footer navigation groups remain present. 
- No changes were made to `/status`, `INDEPENDENT_STATUS_URL`, or local status parsing; the badge is strictly additive.

### Testing
- ✅ `npm run test:run` — unit/test suite passed (all tests). 
- ✅ `npm run lint` — lint completed without errors. 
- ✅ `npm run build` — production build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a9232738c30832ca27816dd433f8083)