### PR TITLE
Finish website refactor routing and metadata cleanup

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -43,7 +43,12 @@ jobs:
         with:
           context: .
           push: false
+          load: true
           tags: ${{ steps.meta.outputs.image_name }}:sha-${{ steps.meta.outputs.short_sha }}
+
+      - name: Validate nginx canonical routes
+        if: github.event_name == 'pull_request'
+        run: ./scripts/validate-nginx.sh "${{ steps.meta.outputs.image_name }}:sha-${{ steps.meta.outputs.short_sha }}"
 
       - name: Build and push image (main)
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: test lint build helm-lint helm-template helm-validate ci-checks
+.PHONY: test lint build nginx-validate helm-lint helm-template helm-validate ci-checks
 
 test:
 	npm run test:run
@@ -8,6 +8,9 @@ lint:
 
 build:
 	npm run build
+
+nginx-validate:
+	./scripts/validate-nginx.sh
 
 helm-lint:
 	helm lint charts/ckconflux-react

--- a/nginx.conf
+++ b/nginx.conf
@@ -11,6 +11,17 @@ server {
     internal;
   }
 
+  # Keep generated HTML files as internal implementation details. Exact and
+  # regex locations only match browser-facing .html requests; try_files below
+  # can still serve those files for their extensionless canonical routes.
+  location = /index.html {
+    return 308 /;
+  }
+
+  location ~ ^/(.+)\.html$ {
+    return 308 /$1;
+  }
+
   location = / {
     try_files /index.html =404;
   }

--- a/nginx.conf
+++ b/nginx.conf
@@ -15,11 +15,11 @@ server {
   # regex locations only match browser-facing .html requests; try_files below
   # can still serve those files for their extensionless canonical routes.
   location = /index.html {
-    return 308 /;
+    return 308 /$is_args$args;
   }
 
   location ~ ^/(.+)\.html$ {
-    return 308 /$1;
+    return 308 /$1$is_args$args;
   }
 
   location = / {

--- a/nginx.conf
+++ b/nginx.conf
@@ -2,6 +2,10 @@ server {
   listen 80;
   server_name _;
 
+  # Emit relative redirects so canonicalization stays correct behind TLS-terminating
+  # ingress/proxies and does not leak the container's internal HTTP port/scheme.
+  absolute_redirect off;
+
   root /usr/share/nginx/html;
   index index.html;
 

--- a/scripts/prerender-routes.mjs
+++ b/scripts/prerender-routes.mjs
@@ -22,7 +22,7 @@ function renderMetadata(pathname, { notFound = false } = {}) {
     .replace(/<meta\s+name=["']description["'][^>]*>/i, `<meta name="description" content="${description}" />`);
 
   const routeTags = [
-    notFound ? '<meta name="robots" content="noindex, nofollow" />' : `<link rel="canonical" href="${url}" />`,
+    notFound ? `<meta name="robots" content="${escapeHtml(metadata.robots)}" />` : `<link rel="canonical" href="${url}" />`,
     '<meta property="og:type" content="website" />',
     `<meta property="og:title" content="${title}" />`,
     `<meta property="og:description" content="${description}" />`,

--- a/scripts/validate-nginx.sh
+++ b/scripts/validate-nginx.sh
@@ -33,18 +33,40 @@ assert_status() {
   path=$1
   expected=$2
   actual=$(curl -sS -o /dev/null -w '%{http_code}' "$base_url$path")
-  test "$actual" = "$expected" || {
+  if [ "$actual" != "$expected" ]; then
     echo "Expected $path to return $expected, got $actual" >&2
     exit 1
-  }
+  fi
 }
 
 assert_redirect() {
   path=$1
   expected_location=$2
   headers=$(curl -sS -D - -o /dev/null "$base_url$path")
-  echo "$headers" | tr -d '\r' | grep -q '^HTTP/1.1 308 '
-  echo "$headers" | tr -d '\r' | grep -Fqx "Location: $base_url$expected_location"
+  status=$(printf '%s\n' "$headers" | tr -d '\r' | sed -n '1s#^HTTP/[0-9.]* \([0-9][0-9][0-9]\).*$#\1#p')
+  location=$(printf '%s\n' "$headers" | tr -d '\r' | sed -n 's/^Location: //p' | head -n 1)
+
+  if [ "$status" != "308" ]; then
+    echo "Expected $path to return 308, got ${status:-unknown}" >&2
+    printf '%s\n' "$headers" >&2
+    exit 1
+  fi
+
+  if [ "$location" != "$expected_location" ]; then
+    echo "Expected $path Location to be $expected_location, got ${location:-missing}" >&2
+    printf '%s\n' "$headers" >&2
+    exit 1
+  fi
+}
+
+assert_title() {
+  path=$1
+  expected=$2
+  body=$(curl -fsS "$base_url$path")
+  if ! printf '%s\n' "$body" | grep -Fq "<title>$expected</title>"; then
+    echo "Expected $path title to be '$expected'" >&2
+    exit 1
+  fi
 }
 
 wait_for_nginx
@@ -57,8 +79,7 @@ assert_redirect /privacy.html /privacy
 assert_redirect /index.html /
 assert_status /does-not-exist 404
 assert_status /404.html 404
-
-curl -fsS "$base_url/help" | grep -q '<title>Help | CK Conflux</title>'
-curl -fsS "$base_url/privacy" | grep -q '<title>Privacy Policy | CK Conflux</title>'
+assert_title /help 'Help | CK Conflux'
+assert_title /privacy 'Privacy Policy | CK Conflux'
 
 echo "nginx route validation passed"

--- a/scripts/validate-nginx.sh
+++ b/scripts/validate-nginx.sh
@@ -1,0 +1,49 @@
+#!/bin/sh
+set -eu
+
+IMAGE=${1:-ckconflux-react:nginx-validation}
+
+if [ "$#" -eq 0 ]; then
+  docker build -t "$IMAGE" .
+fi
+
+container=$(docker run --rm -d -p 127.0.0.1::80 "$IMAGE")
+cleanup() {
+  docker rm -f "$container" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT INT TERM
+
+port=$(docker port "$container" 80/tcp | sed -n '1s/.*://p')
+base_url="http://127.0.0.1:$port"
+
+assert_status() {
+  path=$1
+  expected=$2
+  actual=$(curl -sS -o /dev/null -w '%{http_code}' "$base_url$path")
+  test "$actual" = "$expected" || {
+    echo "Expected $path to return $expected, got $actual" >&2
+    exit 1
+  }
+}
+
+assert_redirect() {
+  path=$1
+  expected_location=$2
+  headers=$(curl -sS -D - -o /dev/null "$base_url$path")
+  echo "$headers" | tr -d '\r' | grep -q '^HTTP/1.1 308 '
+  echo "$headers" | tr -d '\r' | grep -Fqx "Location: $base_url$expected_location"
+}
+
+assert_status / 200
+assert_status /help 200
+assert_status /privacy 200
+assert_redirect '/help.html?from=validation' '/help?from=validation'
+assert_redirect /privacy.html /privacy
+assert_redirect /index.html /
+assert_status /does-not-exist 404
+assert_status /404.html 404
+
+curl -fsS "$base_url/help" | grep -q '<title>Help | CK Conflux</title>'
+curl -fsS "$base_url/privacy" | grep -q '<title>Privacy Policy | CK Conflux</title>'
+
+echo "nginx route validation passed"

--- a/scripts/validate-nginx.sh
+++ b/scripts/validate-nginx.sh
@@ -16,6 +16,19 @@ trap cleanup EXIT INT TERM
 port=$(docker port "$container" 80/tcp | sed -n '1s/.*://p')
 base_url="http://127.0.0.1:$port"
 
+wait_for_nginx() {
+  attempts=0
+  while ! curl -sS -o /dev/null "$base_url/" 2>/dev/null; do
+    attempts=$((attempts + 1))
+    if [ "$attempts" -ge 30 ]; then
+      echo "nginx did not become ready at $base_url" >&2
+      docker logs "$container" >&2 || true
+      exit 1
+    fi
+    sleep 0.2
+  done
+}
+
 assert_status() {
   path=$1
   expected=$2
@@ -34,10 +47,12 @@ assert_redirect() {
   echo "$headers" | tr -d '\r' | grep -Fqx "Location: $base_url$expected_location"
 }
 
+wait_for_nginx
 assert_status / 200
 assert_status /help 200
 assert_status /privacy 200
 assert_redirect '/help.html?from=validation' '/help?from=validation'
+assert_redirect '/index.html?from=validation' '/?from=validation'
 assert_redirect /privacy.html /privacy
 assert_redirect /index.html /
 assert_status /does-not-exist 404

--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -4,7 +4,7 @@ import App from './App';
 
 const renderPath = (path) => { window.history.pushState({}, '', path); return render(<App />); };
 beforeEach(() => { vi.stubGlobal('fetch', vi.fn(() => new Promise(() => {}))); });
-afterEach(() => { vi.unstubAllGlobals(); document.title = ''; document.head.querySelectorAll('link[rel="canonical"], meta[property^="og:"], meta[name^="twitter:"]').forEach((node) => node.remove()); });
+afterEach(() => { vi.unstubAllGlobals(); document.title = ''; document.head.querySelectorAll('link[rel="canonical"], meta[property^="og:"], meta[name^="twitter:"], meta[name="robots"]').forEach((node) => node.remove()); });
 
 describe('CK Conflux application architecture', () => {
   it('renders the compact promotional Home and primary destinations', () => {
@@ -101,6 +101,29 @@ describe('CK Conflux application architecture', () => {
     expect(screen.getByRole('heading', { name: 'Server Rules' })).toBeInTheDocument();
   });
 
+  it('keeps an exact same-URL navigation as a no-op', () => {
+    renderPath('/');
+    const pushState = vi.spyOn(window.history, 'pushState');
+    fireEvent.click(screen.getByRole('link', { name: 'CK Conflux' }));
+    expect(pushState).not.toHaveBeenCalled();
+  });
+
+  it('clears a stale fragment when navigating to the current pathname and restores page focus', () => {
+    renderPath('/#signin');
+    fireEvent.click(screen.getByRole('link', { name: 'CK Conflux' }));
+    expect(window.location.pathname).toBe('/');
+    expect(window.location.hash).toBe('');
+    expect(screen.getByRole('heading', { name: /Private community chat/i })).toHaveFocus();
+  });
+
+  it('clears stale search state when navigating to the same pathname', () => {
+    renderPath('/help?source=old');
+    fireEvent.click(screen.getByRole('navigation', { name: 'Primary navigation' }).querySelector('a[href="/help"]'));
+    expect(window.location.pathname).toBe('/help');
+    expect(window.location.search).toBe('');
+    expect(screen.getByRole('heading', { name: /Matrix onboarding/i })).toHaveFocus();
+  });
+
   it('preserves initial focus and moves focus after client navigation', () => {
     renderPath('/');
     const homeHeading = screen.getByRole('heading', { name: /Private community chat, secure messaging/i });
@@ -117,6 +140,36 @@ describe('CK Conflux application architecture', () => {
     expect(document.querySelector('link[rel="canonical"]')).toHaveAttribute('href', 'https://ckconflux.com/security');
     expect(document.querySelector('meta[property="og:title"]')).toHaveAttribute('content', 'Security | CK Conflux');
     expect(document.querySelector('meta[name="twitter:card"]')).toHaveAttribute('content', 'summary');
+    expect(document.querySelector('meta[name="description"]')).toHaveAttribute('content', 'Learn about Matrix encryption, secure backup, recovery keys, device verification, and federation boundaries.');
+    expect(document.querySelector('meta[name="robots"]')).not.toBeInTheDocument();
+  });
+
+  it('removes a prerendered 404 robots directive on a valid route', async () => {
+    document.head.insertAdjacentHTML('beforeend', '<meta name="robots" content="noindex, nofollow">');
+    renderPath('/');
+    await waitFor(() => expect(document.querySelector('meta[name="robots"]')).not.toBeInTheDocument());
+  });
+
+  it('applies noindex metadata to an unknown route', async () => {
+    renderPath('/does-not-exist');
+    await waitFor(() => expect(document.querySelector('meta[name="robots"]')).toHaveAttribute('content', 'noindex, nofollow'));
+    expect(document.title).toBe('Page Not Found | CK Conflux');
+    expect(document.querySelector('link[rel="canonical"]')).toHaveAttribute('href', 'https://ckconflux.com/does-not-exist');
+  });
+
+  it('removes 404 robots metadata after client navigation to a valid route', async () => {
+    renderPath('/does-not-exist');
+    await waitFor(() => expect(document.querySelector('meta[name="robots"]')).toBeInTheDocument());
+    fireEvent.click(screen.getByRole('link', { name: 'CK Conflux' }));
+    await waitFor(() => expect(document.querySelector('meta[name="robots"]')).not.toBeInTheDocument());
+    expect(document.title).toBe('CK Conflux');
+  });
+
+  it('applies 404 robots metadata after client navigation to an unknown route', async () => {
+    renderPath('/help');
+    act(() => { window.history.pushState({}, '', '/missing'); window.dispatchEvent(new PopStateEvent('popstate')); });
+    await waitFor(() => expect(document.querySelector('meta[name="robots"]')).toHaveAttribute('content', 'noindex, nofollow'));
+    expect(screen.getByRole('heading', { name: 'Page not found' })).toHaveFocus();
   });
 
   it('distinguishes Matrix, CK Conflux, and Element for general users', () => {
@@ -154,6 +207,15 @@ describe('CK Conflux application architecture', () => {
     expect(screen.getByRole('link', { name: 'Official TeamSpeak downloads' })).toHaveAttribute('href', 'https://www.teamspeak.com/en/downloads/');
     expect(screen.getByRole('link', { name: 'Explore Element Call' })).toHaveAttribute('href', '/calls');
     expect(screen.getByText(/identity and setup are separate/)).toBeInTheDocument();
+  });
+
+  it('exposes Mastodon as a secondary service from Help without changing primary navigation', () => {
+    renderPath('/help');
+    fireEvent.click(screen.getByRole('button', { name: /What about Mastodon or TeamSpeak support?/ }));
+    expect(screen.getByRole('link', { name: 'Open CK Conflux Mastodon' })).toHaveAttribute('href', 'https://masto.colonelkrud.com');
+    expect(screen.getByText(/secondary supported social service/)).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'TeamSpeak page' })).toHaveAttribute('href', '/teamspeak');
+    expect(screen.getByRole('navigation', { name: 'Primary navigation' })).not.toHaveTextContent('Mastodon');
   });
 
   it('does not market Foundry VTT', () => {

--- a/src/config/community.js
+++ b/src/config/community.js
@@ -2,6 +2,7 @@ const GIBIBYTE_IN_BYTES = 1024 ** 3;
 const COMMUNITY_MEDIA_GIBIBYTES = 10;
 
 export const ACCOUNT_PORTAL_URL = 'https://account.ckconflux.com';
+export const MASTODON_SERVICE_URL = 'https://masto.colonelkrud.com';
 
 export const COMMUNITY_MEDIA_QUOTA = Object.freeze({
   gibibytes: COMMUNITY_MEDIA_GIBIBYTES,

--- a/src/metadata/Metadata.jsx
+++ b/src/metadata/Metadata.jsx
@@ -14,6 +14,9 @@ export default function Metadata({ pathname }) {
     for (const property of ['og:title','og:description','og:url']) upsertMeta(`meta[property="${property}"]`, 'property', property, property === 'og:title' ? metadata.title : property === 'og:description' ? metadata.description : metadata.url);
     for (const name of ['twitter:title','twitter:description']) upsertMeta(`meta[name="${name}"]`, 'name', name, name.endsWith('title') ? metadata.title : metadata.description);
     upsertMeta('meta[name="twitter:card"]', 'name', 'twitter:card', 'summary');
+    const robots = document.head.querySelector('meta[name="robots"]');
+    if (metadata.robots) upsertMeta('meta[name="robots"]', 'name', 'robots', metadata.robots);
+    else robots?.remove();
     let canonical = document.head.querySelector('link[rel="canonical"]');
     if (!canonical) { canonical = document.createElement('link'); canonical.rel = 'canonical'; document.head.append(canonical); }
     canonical.href = metadata.url;

--- a/src/metadata/pageMetadata.js
+++ b/src/metadata/pageMetadata.js
@@ -27,5 +27,6 @@ export function getPageMetadata(pathname) {
     description: known ? descriptions[pathname] : 'The requested CK Conflux page could not be found.',
     url: `${SITE_URL}${pathname}`,
     known,
+    robots: known ? null : 'noindex, nofollow',
   };
 }

--- a/src/pages/Help.jsx
+++ b/src/pages/Help.jsx
@@ -1,6 +1,6 @@
 import { useId, useState } from 'react';
 import { Link } from '../router/Router';
-import { ACCOUNT_PORTAL_URL } from '../config/community';
+import { ACCOUNT_PORTAL_URL, MASTODON_SERVICE_URL } from '../config/community';
 
 function AccordionItem({ title, children, defaultOpen = false }) {
   const [isOpen, setIsOpen] = useState(defaultOpen);
@@ -48,7 +48,7 @@ const faqItems = [
   { q: 'How do I report, ignore, or block someone?', a: <p>Open the message or user actions in your client to report, ignore, or block. Include room links, timestamps, and relevant context in a report. Blocking or ignoring changes your experience; reporting asks moderators to review conduct under the <Link className="font-semibold text-cyan-200 underline" to="/rules">Rules</Link>. Encrypted reports may require you to provide the content moderators need.</p> },
   { q: 'Do messages and media stay forever?', a: <p>Do not assume indefinite retention. Storage and retention vary by service, room, account state, operations, and federation. Encrypted Matrix media may be stored as ciphertext; this does not mean the server can scan every upload in plaintext. See <Link className="font-semibold text-cyan-200 underline" to="/privacy">Privacy</Link>.</p> },
   { q: 'How do registration codes work?', a: <p>Share a registration code privately, outside Element. A friend enters it during registration. Codes may be revoked for abuse, spam, or policy violations. Existing members or a supported tier at <a className="font-semibold text-cyan-200 underline" href="https://buymeacoffee.com/conflux">Buy Me a Coffee</a> may provide a token.</p> },
-  { q: 'What about Mastodon or TeamSpeak support?', a: <p>Mastodon reports use the post or account report menu; mute and block are also available. TeamSpeak is a separate beta service: provide admins the username, channel, and incident time when reporting. Its identity and recovery are separate from Matrix. See the <Link className="font-semibold text-cyan-200 underline" to="/teamspeak">TeamSpeak page</Link>.</p> },
+  { q: 'What about Mastodon or TeamSpeak support?', a: <p><a className="font-semibold text-cyan-200 underline" href={MASTODON_SERVICE_URL}>Open CK Conflux Mastodon</a> to use the secondary supported social service. Mastodon reports use the post or account report menu; mute and block are also available. TeamSpeak is a separate beta service: provide admins the username, channel, and incident time when reporting. Its identity and recovery are separate from Matrix. See the <Link className="font-semibold text-cyan-200 underline" to="/teamspeak">TeamSpeak page</Link>.</p> },
 ];
 
 export default function HelpPage() {

--- a/src/router/Router.jsx
+++ b/src/router/Router.jsx
@@ -11,8 +11,10 @@ export function Router({ children }) {
     return () => window.removeEventListener('popstate', handlePopState);
   }, []);
   const navigate = useCallback((to) => {
-    if (to === window.location.pathname) return;
-    window.history.pushState({}, '', to);
+    const destination = new URL(to, window.location.origin);
+    const current = window.location;
+    if (destination.pathname === current.pathname && destination.search === current.search && destination.hash === current.hash) return;
+    window.history.pushState({}, '', `${destination.pathname}${destination.search}${destination.hash}`);
     setLocation((current) => ({ pathname: window.location.pathname, navigationKey: current.navigationKey + 1 }));
   }, []);
   const value = useMemo(() => ({ pathname: location.pathname, navigationKey: location.navigationKey, navigate }), [location, navigate]);


### PR DESCRIPTION
### Motivation
- #30 root cause: Nginx served generated `*.html` files as public canonical routes while the client router only recognizes extensionless paths, causing `.html` requests to return a client-side Not Found state instead of canonical extensionless URLs.\
- #31 root cause: client navigation compared only `pathname`, so navigating to the same pathname did not clear stale `search` or `hash` state (for example `/#signin` → `/`).\
- #32 root cause: prerendered `404.html` emitted `meta[name="robots"]="noindex, nofollow"` but client metadata updates never removed or re-applied that directive, leaving stale noindex state after client navigation.\
- #36 root cause: Help content referenced Mastodon but exposed no clickable entry point to the supported Mastodon host. The change prefers adding a discoverable Help link backed by a centralized service URL.\

### Description
- Nginx canonicalization: added precise rules to redirect public `*.html` requests to extensionless canonical routes with `308` (permanent) responses while keeping `try_files $uri $uri.html =404;` intact so extensionless routes still resolve to generated files; `index.html` now redirects to `/`; `/404.html` remains `internal`.\
- Router navigation: replaced the simplistic pathname equality check with URL resolution and full comparison of `pathname`, `search`, and `hash` so same-path navigations clear stale fragments/search when appropriate and preserve true no-op behavior for identical full locations.\
- Metadata lifecycle: centralized the Not-Found robots policy in `getPageMetadata()` (unknown routes return `robots: 'noindex, nofollow'`) and made `Metadata.jsx` apply or remove the `meta[name="robots"]` node on client transitions while leaving canonical/title/description/OG/Twitter behavior unchanged.\
- Mastodon link: introduced `MASTODON_SERVICE_URL` in `src/config/community.js` and added a semantic, visible link in the existing Help FAQ entry (no homepage or primary navigation changes; TeamSpeak and Matrix/Element prominence unchanged).\
- Tests & CI hooks: added focused regressions in `src/App.test.jsx` for same-URL no-op, fragment clearing, stale-query clearing, metadata lifecycle (404 robots add/remove), and Help Mastodon discoverability; added `scripts/validate-nginx.sh` (container validation) and wired it into PR Docker job so PR images validate canonical redirects.\

### Testing
- Unit/browser tests: `npm run test:run` — passed (50 tests).\
- Lint: `npm run lint` — passed.\
- Production build + prerender: `npm run build` — passed and prerender assertions succeeded (dist contains generated HTML routes; `dist/404.html` contains `meta[name="robots"]="noindex, nofollow"` while valid pages do not).\
- Additional checks run locally: `git diff --check` — passed. Prerender validation command used: `test "$(find dist -maxdepth 1 -name '*.html' | wc -l)" -ge 3 && grep -q '<meta name="robots" content="noindex, nofollow"' dist/404.html && ! grep -q 'name="robots"' dist/help.html && grep -q '<title>Help | CK Conflux</title>' dist/help.html` — passed.\
- Nginx validation script: `./scripts/validate-nginx.sh` performs container checks for: `/ -> 200`, `/help -> 200`, `/help.html -> 308 -> /help` (query preserved), `/privacy.html -> 308 -> /privacy`, `/index.html -> 308 -> /`, `/does-not-exist -> 404`, and `/404.html -> 404 (internal behavior preserved)`; this script cannot be executed in the authoring environment because Docker/Helm were not available, but it is invoked in the PR Docker job via the workflow.\

Notes and confirmations
- Nginx canonicalization behavior called out: public `*.html` requests return `308` to the extensionless canonical path, `/index.html` redirects to `/`, query strings are preserved for redirects, and internal `404.html` remains internal; internal `try_files` still allows nginx to serve prerendered files for extensionless requests.\
- No new dependencies were added.\
- Mastodon remains a secondary, discoverable service exposed only from Help (Matrix/Element and Element Call remain primary; TeamSpeak remains a separate/beta route).\

Closes #30
Closes #31
Closes #32
Closes #36

Completes the remaining implementation work currently blocking review/closure of #27 and #15.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a9238b87498832cb691d252c2105239)