### PR TITLE
Align public contacts with canonical Apps GitOps contract

### DIFF
--- a/charts/ckconflux-react/Chart.yaml
+++ b/charts/ckconflux-react/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: ckconflux-react
 description: Helm chart for deploying the ckconflux-react static web app.
 type: application
-version: 0.1.1
+version: 0.1.2
 appVersion: "0.1.0"
 kubeVersion: ">=1.26.0-0"
 home: https://github.com/colonelkrud/ckconflux-react
@@ -14,5 +14,5 @@ keywords:
   - nginx
 maintainers:
   - name: Colonelkrud
-    email: colonelkrud@gmail.com
+    email: support@ckconflux.com
     url: https://ckconflux.com

--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -296,16 +296,36 @@ describe('CK Conflux application architecture', () => {
 
   it('routes support intents and exposes the independent status link', () => {
     renderPath('/support');
+    expect(screen.getByRole('heading', { name: 'Forgot account password' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Verification email problem' })).toBeInTheDocument();
     expect(screen.getByRole('heading', { name: 'Can sign in but old encrypted messages are unavailable' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'No recovery key and no verified device' })).toBeInTheDocument();
     expect(screen.getByRole('heading', { name: 'Harassment or abuse' })).toBeInTheDocument();
     expect(screen.getByRole('heading', { name: 'Privacy or data request' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Service outage' })).toBeInTheDocument();
     expect(screen.getByRole('heading', { name: 'Membership or storage' })).toBeInTheDocument();
     expect(screen.getByRole('link', { name: 'Reset password in Element' })).toHaveAttribute('href', 'https://element.ckconflux.com/#/forgot_password');
     expect(screen.getByRole('link', { name: 'Reset password in Element' }).compareDocumentPosition(screen.getAllByRole('link', { name: 'Email account support' })[0]) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
     expect(screen.getByText(/password reset does not recreate encryption keys/i)).toBeInTheDocument();
-    expect(screen.getByRole('link', { name: 'Email abuse' })).toHaveAttribute('href', 'mailto:abuse@ckconflux.com');
-    expect(screen.getByRole('link', { name: 'Privacy contact' })).toHaveAttribute('href', 'mailto:privacy@ckconflux.com');
+    expect(screen.getByRole('link', { name: 'Email security' })).toHaveAttribute('href', 'mailto:abuse@mg.ckconflux.com');
+    expect(screen.getByRole('link', { name: 'Email abuse' })).toHaveAttribute('href', 'mailto:abuse@mg.ckconflux.com');
+    expect(screen.getByRole('link', { name: 'Privacy contact' })).toHaveAttribute('href', 'mailto:abuse@mg.ckconflux.com');
     expect(screen.getByRole('link', { name: 'Independent status page' })).toHaveAttribute('href', 'https://status.ckconflux.com');
+  });
+
+  it.each([
+    ['/privacy', ['abuse@mg.ckconflux.com']],
+    ['/terms', ['abuse@mg.ckconflux.com']],
+    ['/support', ['support@ckconflux.com', 'abuse@mg.ckconflux.com']],
+  ])('publishes only canonical contact addresses on %s', (path, expectedAddresses) => {
+    renderPath(path);
+    const addresses = [...document.querySelectorAll('a[href^="mailto:"]')]
+      .map((link) => link.getAttribute('href').slice('mailto:'.length));
+
+    expect(new Set(addresses)).toEqual(new Set(expectedAddresses));
+    expect(addresses).not.toContain('abuse@ckconflux.com');
+    expect(addresses).not.toContain('security@ckconflux.com');
+    expect(addresses).not.toContain('privacy@ckconflux.com');
   });
 
   it('renders successful component status and its generation time', async () => {

--- a/src/config/community.js
+++ b/src/config/community.js
@@ -13,13 +13,14 @@ export const PASSWORD_RECOVERY_URL = `${ELEMENT_URL}/#/forgot_password`;
 export const ELEMENT_IDENTITY_RESET_GUIDE_URL = 'https://docs.element.io/latest/element-support/matrix-account-management/managing-a-matrix-account/#resetting-your-identity';
 
 const contact = (email) => Object.freeze({ email, mailto: `mailto:${email}` });
+const sharedAbuseContact = contact('abuse@mg.ckconflux.com');
 
 // Canonical public contacts defined by ck-conflux-apps-gitops#372.
 export const PUBLIC_CONTACTS = Object.freeze({
   support: contact('support@ckconflux.com'),
-  abuse: contact('abuse@ckconflux.com'),
-  security: contact('security@ckconflux.com'),
-  privacy: contact('privacy@ckconflux.com'),
+  abuse: sharedAbuseContact,
+  security: sharedAbuseContact,
+  privacy: sharedAbuseContact,
 });
 
 export const COMMUNITY_MEDIA_ALLOWANCES = Object.freeze({

--- a/src/config/community.test.js
+++ b/src/config/community.test.js
@@ -2,12 +2,23 @@ import { describe, expect, it } from 'vitest';
 import { PUBLIC_CONTACTS } from './community';
 
 describe('canonical public contacts', () => {
-  it('keeps distinct intent addresses in the shared frontend contract', () => {
+  it('maps each intent to the canonical public endpoint', () => {
     expect(PUBLIC_CONTACTS).toEqual({
       support: { email: 'support@ckconflux.com', mailto: 'mailto:support@ckconflux.com' },
-      abuse: { email: 'abuse@ckconflux.com', mailto: 'mailto:abuse@ckconflux.com' },
-      security: { email: 'security@ckconflux.com', mailto: 'mailto:security@ckconflux.com' },
-      privacy: { email: 'privacy@ckconflux.com', mailto: 'mailto:privacy@ckconflux.com' },
+      abuse: { email: 'abuse@mg.ckconflux.com', mailto: 'mailto:abuse@mg.ckconflux.com' },
+      security: { email: 'abuse@mg.ckconflux.com', mailto: 'mailto:abuse@mg.ckconflux.com' },
+      privacy: { email: 'abuse@mg.ckconflux.com', mailto: 'mailto:abuse@mg.ckconflux.com' },
     });
+
+    expect(PUBLIC_CONTACTS.security).toBe(PUBLIC_CONTACTS.abuse);
+    expect(PUBLIC_CONTACTS.privacy).toBe(PUBLIC_CONTACTS.abuse);
+  });
+
+  it('does not publish invented intent aliases', () => {
+    const publishedEmails = Object.values(PUBLIC_CONTACTS).map(({ email }) => email);
+
+    expect(publishedEmails).not.toContain('abuse@ckconflux.com');
+    expect(publishedEmails).not.toContain('security@ckconflux.com');
+    expect(publishedEmails).not.toContain('privacy@ckconflux.com');
   });
 });


### PR DESCRIPTION
### Motivation
- The frontend published invented intent aliases (`abuse@ckconflux.com`, `security@ckconflux.com`, `privacy@ckconflux.com`) that differ from the landed canonical Apps GitOps contract and must be corrected. 
- The change is limited to publishing the canonical contract values and preventing future drift while preserving existing recovery and routing behavior.

### Description
- Replace distinct abuse/security/privacy aliases with a single shared contact `abuse@mg.ckconflux.com` and keep `support@ckconflux.com` for general/account support by updating `src/config/community.js`.
- Add drift-prevention and rendering tests in `src/config/community.test.js` and tighten application-level assertions in `src/App.test.jsx` to verify canonical addresses and that distinct user intents remain separately surfaced. 
- Update rendered pages to consume the centralized values (tests validate `/support`, `/privacy`, and `/terms` outputs) and avoid publishing unevidenced aliases. 
- Bump Helm chart patch version and replace the stale maintainer email with `support@ckconflux.com` in `charts/ckconflux-react/Chart.yaml` (no new dependencies added).

```
Closes #49
Related #40
Canonical contract: colonelkrud/ck-conflux-apps-gitops#372
Implemented by Apps GitOps PR #373
```

This PR fixes the premature modeling from the previous change by routing abuse, moderation, security, privacy, and data-request intents to the intentionally shared `abuse@mg.ckconflux.com` endpoint while keeping `support@ckconflux.com` for general/account support.

### Testing
- Ran `npm run test:run` and observed: 3 test files passed and 59 tests passed. 
- Ran `npm run lint` and `npm run build`, both succeeded and production asset checks passed. 
- Performed focused repository searches asserting that the forbidden aliases (`abuse@ckconflux.com`, `security@ckconflux.com`, `privacy@ckconflux.com`, `admin@colonelkrud.com`, `abuse@mg.colonelkrud.com`, `colonelkrud@gmail.com`) are not present in maintained application surfaces. 
- CI-only tools `helm lint` and `kubeconform` were not available in the local environment; these will run in upstream CI.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a92d6f18c64832c816b078f469c5dcd)