### PR TITLE
Improve the CK Conflux end-user status experience

### DIFF
--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -392,16 +392,20 @@ describe('CK Conflux application architecture', () => {
   it('renders successful component status and its generation time', async () => {
     fetch.mockResolvedValue({ ok: true, json: async () => ({ generated_at: '2026-08-26T12:00:00Z', components: { website: 'healthy', authentication: 'up', matrix: 'operational', media: 'ok', calls: 'available', membership: 'passing' } }) });
     renderPath('/status');
-    expect(await screen.findByText('Overall: Operational')).toBeInTheDocument();
-    expect(screen.getByText('Matrix messaging')).toBeInTheDocument();
-    expect(screen.getByText('Voice / video calls')).toBeInTheDocument();
-    expect(screen.getByText(/Status payload updated:/)).toBeInTheDocument();
+    expect(await screen.findByRole('heading', { name: 'All systems operational' })).toBeInTheDocument();
+    expect(screen.getByText('Messaging')).toBeInTheDocument();
+    expect(screen.getByText('Voice & video')).toBeInTheDocument();
+    expect(document.querySelector('time')).toHaveAttribute('datetime', '2026-08-26T12:00:00Z');
+    expect(screen.getByRole('button', { name: 'Refresh' })).toBeInTheDocument();
+    const overall = screen.getByRole('heading', { name: /overall ck conflux status/i });
+    const independent = screen.getByRole('heading', { name: 'Independent monitoring' });
+    expect(overall.compareDocumentPosition(independent) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
   });
 
   it('renders degraded status without claiming all systems operational', async () => {
     fetch.mockResolvedValue({ ok: true, json: async () => ({ components: { website: 'operational', matrix: 'degraded' } }) });
     renderPath('/');
-    expect(await screen.findByText('Some systems are degraded')).toBeInTheDocument();
+    expect(await screen.findByText('Messaging is degraded')).toBeInTheDocument();
     expect(document.body).not.toHaveTextContent('All systems operational');
   });
 
@@ -411,14 +415,41 @@ describe('CK Conflux application architecture', () => {
   ])('shows unknown status for a %s', async (_name, response) => {
     fetch.mockImplementation(response);
     renderPath('/status');
-    expect(await screen.findByRole('heading', { name: 'Local status unavailable / unknown' })).toBeInTheDocument();
+    expect(await screen.findByRole('heading', { name: "We couldn't retrieve CK Conflux service health" })).toBeInTheDocument();
     expect(document.body).not.toHaveTextContent('All systems operational');
   });
 
   it('prominently links the authoritative independent status host', () => {
     renderPath('/status');
-    expect(screen.getByRole('link', { name: 'Open independent status page' })).toHaveAttribute('href', 'https://status.ckconflux.com');
+    expect(screen.getByRole('link', { name: /Open independent status page/ })).toHaveAttribute('href', 'https://status.ckconflux.com');
     expect(document.body).not.toHaveTextContent('status.colonelkrud.com');
+  });
+
+  it('renders a valid HTTP 503 outage payload as degraded status with user impact', async () => {
+    fetch.mockResolvedValue({ ok: false, status: 503, json: async () => ({ status: 'degraded', generated_at: '2026-08-30T12:00:00Z', checks: { website: 'ok', login: 'ok', matrix: 'ok', media: 'ok', calls: 'degraded', membership: 'ok' } }) });
+    renderPath('/status');
+    expect(await screen.findByRole('heading', { name: 'Some services are degraded' })).toBeInTheDocument();
+    expect(screen.getByText('Voice & video').closest('li')).toHaveTextContent('Degraded');
+    expect(screen.getByText('Voice & video').closest('li')).toHaveTextContent(/Calls may fail to connect or may be disrupted/);
+    expect(document.body).not.toHaveTextContent('Local status unavailable / unknown');
+    expect(document.body).not.toHaveTextContent('Synapse');
+  });
+
+  it('distinguishes an unavailable service from a degraded service', async () => {
+    fetch.mockResolvedValue({ ok: false, status: 503, json: async () => ({ checks: { matrix: 'down', calls: 'degraded' } }) });
+    renderPath('/status');
+    expect(await screen.findByRole('heading', { name: 'Service outage detected' })).toBeInTheDocument();
+    expect(screen.getByText('Messaging').closest('li')).toHaveTextContent('Unavailable');
+    expect(screen.getByText('Messaging').closest('li')).toHaveTextContent(/messages may be delayed or fail/i);
+  });
+
+  it('keeps the healthy home summary concise without rendering service rows', async () => {
+    fetch.mockResolvedValue({ ok: true, json: async () => ({ checks: { matrix: 'ok', login: 'ok' } }) });
+    renderPath('/');
+    expect(await screen.findByText('All systems operational')).toBeInTheDocument();
+    expect(document.body).not.toHaveTextContent('State: Operational');
+    expect(screen.getByRole('link', { name: 'View details →' })).toHaveAttribute('href', '/status');
+    expect(screen.queryByRole('heading', { name: 'Services' })).not.toBeInTheDocument();
   });
 
   it('preserves a reduced-motion override and observes the preference', () => {

--- a/src/components/StatusSummary.jsx
+++ b/src/components/StatusSummary.jsx
@@ -2,19 +2,39 @@ import { Link } from '../router/Router';
 import { statusHeadline } from '../status/status';
 import { useLocalStatus } from '../status/useLocalStatus';
 
+function relativeUpdateLabel(value) {
+  const date = value ? new Date(value) : null;
+  if (!date || Number.isNaN(date.getTime())) return null;
+  const seconds = Math.max(0, Math.round((Date.now() - date.getTime()) / 1000));
+  if (seconds < 60) return 'Updated just now';
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `Updated ${minutes} minute${minutes === 1 ? '' : 's'} ago`;
+  const hours = Math.floor(minutes / 60);
+  return `Updated ${hours} hour${hours === 1 ? '' : 's'} ago`;
+}
+
 export default function StatusSummary() {
-  const status = useLocalStatus();
+  const status = useLocalStatus({ refreshIntervalMs: 60000 });
   const affected = status.components.filter(({ state }) => state === 'degraded' || state === 'unavailable');
   let message = status.phase === 'loading' ? 'Checking service status…' : status.phase === 'error' ? 'Status is temporarily unavailable' : statusHeadline(status.overall);
   if (affected.length === 1) message = `${affected[0].name} ${affected[0].state === 'degraded' ? 'is degraded' : 'is unavailable'}`;
+
+  const messagingOperational = status.components.some(({ id, state }) => id === 'messaging' && state === 'operational');
+  const signinOperational = status.components.some(({ id, state }) => id === 'signin' && state === 'operational');
   const supporting = status.phase === 'ready' && affected.length === 1
-    ? (affected[0].id === 'calls' ? 'Messaging and sign-in remain operational.' : 'Other services may remain operational; view details for the full status.')
+    ? (affected[0].id === 'calls' && messagingOperational && signinOperational
+      ? 'Messaging and sign-in remain operational.'
+      : 'Other services may remain operational; view details for the full status.')
     : status.phase === 'ready' && affected.length > 1 ? `${affected.length} services are affected.` : null;
+  const freshness = status.phase === 'ready' && !supporting
+    ? relativeUpdateLabel(status.generatedAt || status.checkedAt)
+    : null;
+
   return <div className="min-h-24 rounded-2xl border border-white/10 bg-white/5 p-5">
     <p className="text-xs font-semibold uppercase tracking-[0.18em] text-cyan-200">Live service status</p>
     <p className="mt-2 text-lg font-semibold text-white" aria-live="polite">{message}</p>
     {supporting && <p className="mt-1 text-sm text-slate-300">{supporting}</p>}
-    {status.phase === 'ready' && !supporting && <p className="mt-1 text-sm text-slate-400">Updated recently</p>}
+    {freshness && <p className="mt-1 text-sm text-slate-400">{freshness}</p>}
     <Link to="/status" className="mt-3 inline-flex text-sm font-semibold text-cyan-200 hover:text-cyan-100">View details →</Link>
   </div>;
 }

--- a/src/components/StatusSummary.jsx
+++ b/src/components/StatusSummary.jsx
@@ -26,7 +26,7 @@ export default function StatusSummary() {
       ? 'Messaging and sign-in remain operational.'
       : 'Other services may remain operational; view details for the full status.')
     : status.phase === 'ready' && affected.length > 1 ? `${affected.length} services are affected.` : null;
-  const freshness = status.phase === 'ready' && !supporting
+  const freshness = status.phase === 'ready'
     ? relativeUpdateLabel(status.generatedAt || status.checkedAt)
     : null;
 
@@ -35,6 +35,7 @@ export default function StatusSummary() {
     <p className="mt-2 text-lg font-semibold text-white" aria-live="polite">{message}</p>
     {supporting && <p className="mt-1 text-sm text-slate-300">{supporting}</p>}
     {freshness && <p className="mt-1 text-sm text-slate-400">{freshness}</p>}
+    {status.stale && <p className="mt-1 text-sm font-semibold text-amber-100" role="status">Unable to refresh. Showing the last known status; it may be out of date.</p>}
     <Link to="/status" className="mt-3 inline-flex text-sm font-semibold text-cyan-200 hover:text-cyan-100">View details →</Link>
   </div>;
 }

--- a/src/components/StatusSummary.jsx
+++ b/src/components/StatusSummary.jsx
@@ -16,26 +16,50 @@ function relativeUpdateLabel(value) {
 export default function StatusSummary() {
   const status = useLocalStatus({ refreshIntervalMs: 60000 });
   const affected = status.components.filter(({ state }) => state === 'degraded' || state === 'unavailable');
-  let message = status.phase === 'loading' ? 'Checking service status…' : status.phase === 'error' ? 'Status is temporarily unavailable' : statusHeadline(status.overall);
-  if (affected.length === 1) message = `${affected[0].name} ${affected[0].state === 'degraded' ? 'is degraded' : 'is unavailable'}`;
+  const snapshotMissing = status.phase === 'ready' && status.stale && status.components.length === 0 && !status.generatedAt;
+
+  let message = status.phase === 'loading'
+    ? 'Checking service status…'
+    : status.phase === 'error'
+      ? 'Status is temporarily unavailable'
+      : snapshotMissing
+        ? 'Status snapshot unavailable'
+        : status.stale
+          ? 'Status information may be out of date'
+          : statusHeadline(status.overall);
+
+  if (!status.stale && affected.length === 1 && affected[0].state === status.overall) {
+    message = `${affected[0].name} ${affected[0].state === 'degraded' ? 'is degraded' : 'is unavailable'}`;
+  }
 
   const messagingOperational = status.components.some(({ id, state }) => id === 'messaging' && state === 'operational');
   const signinOperational = status.components.some(({ id, state }) => id === 'signin' && state === 'operational');
-  const supporting = status.phase === 'ready' && affected.length === 1
-    ? (affected[0].id === 'calls' && messagingOperational && signinOperational
+  let supporting = null;
+  if (status.phase === 'ready' && status.stale) {
+    supporting = snapshotMissing
+      ? 'CK Conflux has not produced a status snapshot yet.'
+      : `Last reported state: ${statusHeadline(status.overall)}.`;
+  } else if (status.phase === 'ready' && affected.length === 1) {
+    supporting = affected[0].id === 'calls' && messagingOperational && signinOperational
       ? 'Messaging and sign-in remain operational.'
-      : 'Other services may remain operational; view details for the full status.')
-    : status.phase === 'ready' && affected.length > 1 ? `${affected.length} services are affected.` : null;
+      : 'Other services may remain operational; view details for the full status.';
+  } else if (status.phase === 'ready' && affected.length > 1) {
+    supporting = `${affected.length} services are affected.`;
+  }
+
   const freshness = status.phase === 'ready'
-    ? relativeUpdateLabel(status.generatedAt || status.checkedAt)
+    ? relativeUpdateLabel(status.generatedAt || (!status.stale ? status.checkedAt : null))
     : null;
+  const staleNotice = snapshotMissing
+    ? 'Current platform health could not be confirmed.'
+    : 'Status snapshot is stale. Showing the last known status; it may be out of date.';
 
   return <div className="min-h-24 rounded-2xl border border-white/10 bg-white/5 p-5">
-    <p className="text-xs font-semibold uppercase tracking-[0.18em] text-cyan-200">Live service status</p>
+    <p className="text-xs font-semibold uppercase tracking-[0.18em] text-cyan-200">{status.stale ? 'Service status' : 'Live service status'}</p>
     <p className="mt-2 text-lg font-semibold text-white" aria-live="polite">{message}</p>
     {supporting && <p className="mt-1 text-sm text-slate-300">{supporting}</p>}
     {freshness && <p className="mt-1 text-sm text-slate-400">{freshness}</p>}
-    {status.stale && <p className="mt-1 text-sm font-semibold text-amber-100" role="status">Unable to refresh. Showing the last known status; it may be out of date.</p>}
+    {status.stale && <p className="mt-1 text-sm font-semibold text-amber-100" role="status">{staleNotice}</p>}
     <Link to="/status" className="mt-3 inline-flex text-sm font-semibold text-cyan-200 hover:text-cyan-100">View details →</Link>
   </div>;
 }

--- a/src/components/StatusSummary.jsx
+++ b/src/components/StatusSummary.jsx
@@ -1,14 +1,20 @@
 import { Link } from '../router/Router';
-import { stateLabel } from '../status/status';
+import { statusHeadline } from '../status/status';
 import { useLocalStatus } from '../status/useLocalStatus';
 
 export default function StatusSummary() {
   const status = useLocalStatus();
-  const message = status.phase === 'loading' ? 'Checking service status…' : status.overall === 'operational' ? 'All systems operational' : status.overall === 'degraded' ? 'Some systems are degraded' : status.overall === 'unavailable' ? 'Some systems are unavailable' : 'Local status unavailable';
-  return <div className="min-h-24 rounded-2xl border border-white/10 bg-white/5 p-5" aria-live="polite">
-    <p className="text-xs font-semibold uppercase tracking-[0.18em] text-cyan-200">Live status</p>
-    <p className="mt-2 text-lg font-semibold text-white">{message}</p>
-    {status.phase !== 'loading' && <p className="mt-1 text-sm text-slate-400">State: {stateLabel(status.overall)}</p>}
-    <Link to="/status" className="mt-3 inline-flex text-sm font-semibold text-cyan-200 hover:text-cyan-100">View service status →</Link>
+  const affected = status.components.filter(({ state }) => state === 'degraded' || state === 'unavailable');
+  let message = status.phase === 'loading' ? 'Checking service status…' : status.phase === 'error' ? 'Status is temporarily unavailable' : statusHeadline(status.overall);
+  if (affected.length === 1) message = `${affected[0].name} ${affected[0].state === 'degraded' ? 'is degraded' : 'is unavailable'}`;
+  const supporting = status.phase === 'ready' && affected.length === 1
+    ? (affected[0].id === 'calls' ? 'Messaging and sign-in remain operational.' : 'Other services may remain operational; view details for the full status.')
+    : status.phase === 'ready' && affected.length > 1 ? `${affected.length} services are affected.` : null;
+  return <div className="min-h-24 rounded-2xl border border-white/10 bg-white/5 p-5">
+    <p className="text-xs font-semibold uppercase tracking-[0.18em] text-cyan-200">Live service status</p>
+    <p className="mt-2 text-lg font-semibold text-white" aria-live="polite">{message}</p>
+    {supporting && <p className="mt-1 text-sm text-slate-300">{supporting}</p>}
+    {status.phase === 'ready' && !supporting && <p className="mt-1 text-sm text-slate-400">Updated recently</p>}
+    <Link to="/status" className="mt-3 inline-flex text-sm font-semibold text-cyan-200 hover:text-cyan-100">View details →</Link>
   </div>;
 }

--- a/src/components/StatusSummary.test.jsx
+++ b/src/components/StatusSummary.test.jsx
@@ -25,6 +25,14 @@ describe('StatusSummary', () => {
     expect(screen.getByText('Other services may remain operational; view details for the full status.')).toBeInTheDocument();
   });
 
+  it('keeps the feed-level outage headline when it is worse than the sole affected component', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(response({ status: 'down', checks: { calls: 'degraded' } })));
+    renderSummary();
+
+    expect(await screen.findByText('Service outage detected')).toBeInTheDocument();
+    expect(screen.queryByText('Voice & video is degraded')).not.toBeInTheDocument();
+  });
+
   it('derives freshness from the payload timestamp instead of permanently saying updated recently', async () => {
     vi.stubGlobal('fetch', vi.fn().mockResolvedValue(response({ generated_at: '2000-01-01T00:00:00Z', checks: { matrix: 'ok', login: 'ok' } })));
     renderSummary();
@@ -32,6 +40,23 @@ describe('StatusSummary', () => {
     expect(await screen.findByText('All systems operational')).toBeInTheDocument();
     expect(screen.queryByText('Updated recently')).not.toBeInTheDocument();
     expect(screen.getByText(/^Updated \d+ hours ago$/)).toBeInTheDocument();
+  });
+
+  it('does not call a server-reported stale healthy snapshot live or operational', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(response({
+      status: 'ok',
+      generated_at: '2000-01-01T00:00:00Z',
+      snapshot_age_seconds: 130,
+      stale: true,
+      messages: [],
+      checks: { website: 'ok', login: 'ok', matrix: 'ok', media: 'ok', calls: 'ok', membership: 'ok' },
+    })));
+    renderSummary();
+
+    expect(await screen.findByText('Status information may be out of date')).toBeInTheDocument();
+    expect(screen.queryByText('All systems operational')).not.toBeInTheDocument();
+    expect(screen.getByText('Service status')).toBeInTheDocument();
+    expect(screen.getByRole('status')).toHaveTextContent('Status snapshot is stale. Showing the last known status; it may be out of date.');
   });
 
   it('keeps freshness visible for an incident and warns when its refresh fails', async () => {
@@ -54,7 +79,7 @@ describe('StatusSummary', () => {
       await vi.advanceTimersByTimeAsync(60000);
       await Promise.resolve();
     });
-    expect(screen.getByRole('status')).toHaveTextContent('Unable to refresh. Showing the last known status; it may be out of date.');
+    expect(screen.getByRole('status')).toHaveTextContent('Status snapshot is stale. Showing the last known status; it may be out of date.');
     expect(fetch).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/components/StatusSummary.test.jsx
+++ b/src/components/StatusSummary.test.jsx
@@ -1,0 +1,35 @@
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { Router } from '../router/Router';
+import StatusSummary from './StatusSummary';
+
+const response = (body) => ({ ok: true, json: async () => body });
+
+function renderSummary() {
+  return render(<Router><StatusSummary /></Router>);
+}
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+describe('StatusSummary', () => {
+  it('does not claim messaging and sign-in are operational without evidence for both', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(response({ checks: { calls: 'degraded', matrix: 'mystery', login: 'ok' } })));
+    renderSummary();
+
+    expect(await screen.findByText('Voice & video is degraded')).toBeInTheDocument();
+    expect(screen.queryByText('Messaging and sign-in remain operational.')).not.toBeInTheDocument();
+    expect(screen.getByText('Other services may remain operational; view details for the full status.')).toBeInTheDocument();
+  });
+
+  it('derives freshness from the payload timestamp instead of permanently saying updated recently', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(response({ generated_at: '2000-01-01T00:00:00Z', checks: { matrix: 'ok', login: 'ok' } })));
+    renderSummary();
+
+    expect(await screen.findByText('All systems operational')).toBeInTheDocument();
+    expect(screen.queryByText('Updated recently')).not.toBeInTheDocument();
+    expect(screen.getByText(/^Updated \d+ hours ago$/)).toBeInTheDocument();
+  });
+});

--- a/src/components/StatusSummary.test.jsx
+++ b/src/components/StatusSummary.test.jsx
@@ -1,4 +1,4 @@
-import { cleanup, render, screen } from '@testing-library/react';
+import { act, cleanup, render, screen } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { Router } from '../router/Router';
 import StatusSummary from './StatusSummary';
@@ -11,6 +11,7 @@ function renderSummary() {
 
 afterEach(() => {
   cleanup();
+  vi.useRealTimers();
   vi.unstubAllGlobals();
 });
 
@@ -31,5 +32,29 @@ describe('StatusSummary', () => {
     expect(await screen.findByText('All systems operational')).toBeInTheDocument();
     expect(screen.queryByText('Updated recently')).not.toBeInTheDocument();
     expect(screen.getByText(/^Updated \d+ hours ago$/)).toBeInTheDocument();
+  });
+
+  it('keeps freshness visible for an incident and warns when its refresh fails', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-08-30T14:00:00Z'));
+    const fetch = vi.fn()
+      .mockResolvedValueOnce(response({ generated_at: '2026-08-30T12:00:00Z', checks: { calls: 'degraded', matrix: 'ok', login: 'ok' } }))
+      .mockRejectedValueOnce(new Error('offline'));
+    vi.stubGlobal('fetch', fetch);
+    renderSummary();
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(screen.getByText('Voice & video is degraded')).toBeInTheDocument();
+    expect(screen.getByText('Updated 2 hours ago')).toBeInTheDocument();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(60000);
+      await Promise.resolve();
+    });
+    expect(screen.getByRole('status')).toHaveTextContent('Unable to refresh. Showing the last known status; it may be out of date.');
+    expect(fetch).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/pages/Status.jsx
+++ b/src/pages/Status.jsx
@@ -56,6 +56,7 @@ export default function Status() {
   const status = useLocalStatus({ refreshIntervalMs: 60000 });
   const error = status.phase === 'error';
   const snapshotMissing = status.phase === 'ready' && status.stale && status.components.length === 0 && !status.generatedAt;
+  const hasUnknownComponent = status.components.some(({ state }) => state === 'unknown');
   const headline = snapshotMissing
     ? 'Status snapshot unavailable'
     : status.stale
@@ -65,7 +66,9 @@ export default function Status() {
     ? 'CK Conflux has not produced a status snapshot yet. Check independent monitoring below for an outside view.'
     : status.stale
       ? `CK Conflux is serving its last completed status snapshot. Last reported state: ${statusHeadline(status.overall)}.`
-      : DETAILS[status.overall];
+      : status.overall === 'unknown' && !hasUnknownComponent
+        ? 'Status information is incomplete; the status feed did not confirm a complete platform state.'
+        : DETAILS[status.overall];
   const statusStyle = status.stale ? STATE_STYLE.degraded : STATE_STYLE[status.overall];
   const statusIcon = status.stale ? '!' : ICONS[status.overall];
   const staleNotice = snapshotMissing

--- a/src/pages/Status.jsx
+++ b/src/pages/Status.jsx
@@ -1,19 +1,75 @@
 import { ExternalLink } from '../components/SiteLink';
-import { INDEPENDENT_STATUS_URL, stateLabel } from '../status/status';
+import {
+  INDEPENDENT_STATUS_BADGE_LINK,
+  INDEPENDENT_STATUS_BADGE_URL,
+  INDEPENDENT_STATUS_URL,
+  stateLabel,
+  statusHeadline,
+} from '../status/status';
 import { useLocalStatus } from '../status/useLocalStatus';
 
+const DETAILS = {
+  operational: 'Messaging, sign-in, calls, media, and account services are reporting healthy.',
+  degraded: 'CK Conflux is available, but one or more services may not work normally.',
+  unavailable: 'One or more CK Conflux services are currently unavailable.',
+  unknown: 'Some service checks returned an unknown state.',
+};
+const IMPACT = {
+  messaging: 'Sending or receiving messages may be delayed or fail.',
+  signin: 'Signing in or creating an account may fail.',
+  calls: 'Calls may fail to connect or may be disrupted.',
+  media: 'Uploading or retrieving files and images may fail.',
+  account: 'My Account or membership-related workflows may be unavailable.',
+  website: 'CK Conflux public web pages may be partially unavailable.',
+};
+const ICONS = { operational: '✓', degraded: '!', unavailable: '×', unknown: '?' };
+const STATE_STYLE = {
+  operational: 'border-emerald-300/30 bg-emerald-400/10 text-emerald-100',
+  degraded: 'border-amber-300/40 bg-amber-400/10 text-amber-100',
+  unavailable: 'border-rose-300/40 bg-rose-400/10 text-rose-100',
+  unknown: 'border-slate-300/30 bg-slate-400/10 text-slate-100',
+};
+
+function relativeTime(value) {
+  const date = value ? new Date(value) : null;
+  if (!date || Number.isNaN(date.getTime())) return null;
+  const seconds = Math.max(0, Math.round((Date.now() - date.getTime()) / 1000));
+  if (seconds < 60) return 'Updated just now';
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `Updated ${minutes} minute${minutes === 1 ? '' : 's'} ago`;
+  const hours = Math.floor(minutes / 60);
+  return `Updated ${hours} hour${hours === 1 ? '' : 's'} ago`;
+}
+
+function Freshness({ status }) {
+  const timestamp = status.generatedAt || status.checkedAt;
+  const date = timestamp ? new Date(timestamp) : null;
+  const valid = date && !Number.isNaN(date.getTime());
+  if (!valid) return null;
+  return <p className="text-sm text-slate-300">
+    <time dateTime={timestamp} title={date.toLocaleString()}>{relativeTime(timestamp)}</time>
+    {!status.generatedAt && <span className="text-slate-400"> (last checked)</span>}
+  </p>;
+}
+
 export default function Status() {
-  const status = useLocalStatus();
-  const unknown = status.phase === 'error';
-  const generatedDate = status.generatedAt ? new Date(status.generatedAt) : null;
-  const generatedLabel = generatedDate && !Number.isNaN(generatedDate.getTime()) ? generatedDate.toLocaleString() : String(status.generatedAt ?? '');
+  const status = useLocalStatus({ refreshIntervalMs: 60000 });
+  const error = status.phase === 'error';
   return <div className="mx-auto w-full max-w-5xl px-4 py-14 sm:px-6 lg:px-8 lg:py-20">
-    <header className="max-w-3xl"><p className="text-sm font-semibold uppercase tracking-[0.18em] text-cyan-200">Availability</p><h1 className="mt-2 text-3xl font-semibold text-white sm:text-4xl">Service status</h1><p className="mt-4 leading-7 text-slate-300">Current health reported from inside the CK Conflux platform.</p></header>
-    <section className="mt-8 rounded-2xl border border-cyan-300/20 bg-cyan-400/5 p-6" aria-labelledby="independent-status"><h2 id="independent-status" className="text-xl font-semibold text-white">Can’t reach CK Conflux?</h2><p className="mt-2 max-w-3xl leading-7 text-slate-300">Our independent, out-of-band status page is hosted separately and remains the place to check when CK Conflux itself is unreachable.</p><ExternalLink href={INDEPENDENT_STATUS_URL} className="mt-5 inline-flex rounded-xl bg-cyan-400 px-5 py-3 font-semibold text-slate-950">Open independent status page</ExternalLink></section>
-    <section className="mt-8" aria-labelledby="local-status"><h2 id="local-status" className="text-2xl font-semibold text-white">In-platform health</h2>
-      {status.phase === 'loading' && <div className="mt-4 min-h-28 rounded-2xl border border-white/10 bg-white/5 p-5 text-slate-300" role="status">Checking local status…</div>}
-      {unknown && <div className="mt-4 min-h-28 rounded-2xl border border-amber-300/30 bg-amber-400/5 p-5"><h3 className="font-semibold text-amber-100">Local status unavailable / unknown</h3><p className="mt-2 text-sm leading-6 text-slate-300">The in-platform status response failed, timed out, was malformed, or did not contain recognized component data. Check the independent status page above.</p></div>}
-      {status.phase === 'ready' && <><p className="mt-3 text-lg font-semibold text-white">Overall: {stateLabel(status.overall)}</p>{status.generatedAt && <p className="mt-1 text-sm text-slate-400">Status payload updated: <time dateTime={status.generatedAt}>{generatedLabel}</time></p>}<ul className="mt-4 grid gap-3 sm:grid-cols-2">{status.components.map((component) => <li key={component.name} className="flex min-h-16 items-center justify-between rounded-xl border border-white/10 bg-white/5 p-4"><span className="text-slate-200">{component.name}</span><strong className="text-white">{stateLabel(component.state)}</strong></li>)}</ul></>}
+    <header className="max-w-3xl"><p className="text-sm font-semibold uppercase tracking-[0.18em] text-cyan-200">Availability</p><h1 className="mt-2 text-3xl font-semibold text-white sm:text-4xl">Service status</h1><p className="mt-4 leading-7 text-slate-300">Current user-facing health reported by CK Conflux.</p></header>
+
+    <section className="mt-8" aria-labelledby="overall-status">
+      <div className="flex flex-wrap items-center justify-between gap-3"><h2 id="overall-status" className="text-sm font-semibold uppercase tracking-[0.16em] text-slate-300">Overall CK Conflux status</h2><button type="button" onClick={status.refresh} disabled={status.isRefreshing} className="rounded-lg border border-white/20 px-4 py-2 text-sm font-semibold text-white hover:border-cyan-200 disabled:cursor-wait disabled:opacity-60">{status.isRefreshing ? 'Refreshing…' : 'Refresh'}</button></div>
+      {status.phase === 'loading' && <div className="mt-4 min-h-32 rounded-2xl border border-white/10 bg-white/5 p-6 text-slate-300" role="status">Checking CK Conflux service health…</div>}
+      {error && <div className="mt-4 rounded-2xl border border-amber-300/40 bg-amber-400/10 p-6" role="alert"><div className="flex items-start gap-4"><span aria-hidden="true" className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full border border-amber-200 font-bold text-amber-100">!</span><div><h3 className="text-xl font-semibold text-white">We couldn't retrieve CK Conflux service health</h3><p className="mt-2 leading-7 text-slate-200">We couldn't retrieve the CK Conflux status feed. This does not necessarily mean the platform is down. Check independent monitoring below for an outside view.</p></div></div></div>}
+      {status.phase === 'ready' && <div className={`mt-4 rounded-2xl border p-6 ${STATE_STYLE[status.overall]}`}><div className="flex items-start gap-4"><span aria-hidden="true" className="flex h-11 w-11 shrink-0 items-center justify-center rounded-full border border-current text-xl font-bold">{ICONS[status.overall]}</span><div><h3 className="text-2xl font-semibold text-white" aria-live="polite" aria-atomic="true">{statusHeadline(status.overall)}</h3><p className="mt-2 leading-7 text-slate-200">{DETAILS[status.overall]}</p><div className="mt-3"><Freshness status={status} /></div>{status.stale && <p className="mt-3 font-semibold text-amber-100" role="status">Unable to refresh. Showing the last known status; it may be out of date.</p>}{status.isRefreshing && <p className="mt-3 text-sm text-slate-300" role="status">Refreshing status…</p>}</div></div></div>}
     </section>
+
+    {status.phase === 'ready' && <section className="mt-10" aria-labelledby="services-status"><h2 id="services-status" className="text-2xl font-semibold text-white">Services</h2><p className="mt-2 text-slate-300">Health is grouped by the CK Conflux features people use.</p><ul className="mt-5 grid gap-3 sm:grid-cols-2">{status.components.map((component) => {
+      const affected = component.state === 'degraded' || component.state === 'unavailable';
+      return <li key={component.id} className={`rounded-xl border p-4 ${affected ? STATE_STYLE[component.state] : 'border-white/10 bg-white/5'}`}><div className="flex items-center justify-between gap-4"><span className="font-medium text-white">{component.name}</span><strong className="flex items-center gap-2 text-sm text-white"><span aria-hidden="true">{ICONS[component.state]}</span>{stateLabel(component.state)}</strong></div>{affected && <p className="mt-3 text-sm leading-6 text-slate-200">{IMPACT[component.id] || 'This service may not work normally.'}</p>}</li>;
+    })}</ul></section>}
+
+    <section className={`mt-10 rounded-2xl border p-6 ${error || status.stale ? 'border-cyan-300/40 bg-cyan-400/10' : 'border-white/10 bg-white/5'}`} aria-labelledby="independent-status"><h2 id="independent-status" className="text-2xl font-semibold text-white">Independent monitoring</h2><p className="mt-3 max-w-3xl leading-7 text-slate-300">CK Conflux service health above is generated from platform and application checks. UptimeRobot independently monitors public CK Conflux endpoints from outside the platform.</p><p className="mt-2 max-w-3xl leading-7 text-slate-300">Use the independent page if CK Conflux itself is unreachable or if you want the outside-in view.</p><ExternalLink href={INDEPENDENT_STATUS_BADGE_LINK} target="_blank" rel="noopener noreferrer" className="mt-5 inline-flex" aria-label="View CK Conflux status on independent monitoring (opens in a new tab)"><img src={INDEPENDENT_STATUS_BADGE_URL} alt="CK Conflux independent monitoring status" className="h-7 max-w-full" /></ExternalLink><div><ExternalLink href={INDEPENDENT_STATUS_URL} target="_blank" rel="noopener noreferrer" className="mt-5 inline-flex rounded-xl bg-cyan-400 px-5 py-3 font-semibold text-slate-950">Open independent status page <span className="sr-only">(opens in a new tab)</span></ExternalLink></div></section>
   </div>;
 }

--- a/src/pages/Status.jsx
+++ b/src/pages/Status.jsx
@@ -9,7 +9,7 @@ import {
 import { useLocalStatus } from '../status/useLocalStatus';
 
 const DETAILS = {
-  operational: 'Messaging, sign-in, calls, media, and account services are reporting healthy.',
+  operational: 'All reported services are healthy.',
   degraded: 'CK Conflux is available, but one or more services may not work normally.',
   unavailable: 'One or more CK Conflux services are currently unavailable.',
   unknown: 'Some service checks returned an unknown state.',

--- a/src/pages/Status.jsx
+++ b/src/pages/Status.jsx
@@ -42,7 +42,7 @@ function relativeTime(value) {
 }
 
 function Freshness({ status }) {
-  const timestamp = status.generatedAt || status.checkedAt;
+  const timestamp = status.generatedAt || (!status.stale ? status.checkedAt : null);
   const date = timestamp ? new Date(timestamp) : null;
   const valid = date && !Number.isNaN(date.getTime());
   if (!valid) return null;
@@ -55,6 +55,23 @@ function Freshness({ status }) {
 export default function Status() {
   const status = useLocalStatus({ refreshIntervalMs: 60000 });
   const error = status.phase === 'error';
+  const snapshotMissing = status.phase === 'ready' && status.stale && status.components.length === 0 && !status.generatedAt;
+  const headline = snapshotMissing
+    ? 'Status snapshot unavailable'
+    : status.stale
+      ? 'Status information may be out of date'
+      : statusHeadline(status.overall);
+  const detail = snapshotMissing
+    ? 'CK Conflux has not produced a status snapshot yet. Check independent monitoring below for an outside view.'
+    : status.stale
+      ? `CK Conflux is serving its last completed status snapshot. Last reported state: ${statusHeadline(status.overall)}.`
+      : DETAILS[status.overall];
+  const statusStyle = status.stale ? STATE_STYLE.degraded : STATE_STYLE[status.overall];
+  const statusIcon = status.stale ? '!' : ICONS[status.overall];
+  const staleNotice = snapshotMissing
+    ? 'Current platform health could not be confirmed.'
+    : 'Status snapshot is stale. Showing the last known status; it may be out of date.';
+
   return <div className="mx-auto w-full max-w-5xl px-4 py-14 sm:px-6 lg:px-8 lg:py-20">
     <header className="max-w-3xl"><p className="text-sm font-semibold uppercase tracking-[0.18em] text-cyan-200">Availability</p><h1 className="mt-2 text-3xl font-semibold text-white sm:text-4xl">Service status</h1><p className="mt-4 leading-7 text-slate-300">Current user-facing health reported by CK Conflux.</p></header>
 
@@ -62,10 +79,10 @@ export default function Status() {
       <div className="flex flex-wrap items-center justify-between gap-3"><h2 id="overall-status" className="text-sm font-semibold uppercase tracking-[0.16em] text-slate-300">Overall CK Conflux status</h2><button type="button" onClick={status.refresh} disabled={status.isRefreshing} className="rounded-lg border border-white/20 px-4 py-2 text-sm font-semibold text-white hover:border-cyan-200 disabled:cursor-wait disabled:opacity-60">{status.isRefreshing ? 'Refreshing…' : 'Refresh'}</button></div>
       {status.phase === 'loading' && <div className="mt-4 min-h-32 rounded-2xl border border-white/10 bg-white/5 p-6 text-slate-300" role="status">Checking CK Conflux service health…</div>}
       {error && <div className="mt-4 rounded-2xl border border-amber-300/40 bg-amber-400/10 p-6" role="alert"><div className="flex items-start gap-4"><span aria-hidden="true" className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full border border-amber-200 font-bold text-amber-100">!</span><div><h3 className="text-xl font-semibold text-white">We couldn't retrieve CK Conflux service health</h3><p className="mt-2 leading-7 text-slate-200">We couldn't retrieve the CK Conflux status feed. This does not necessarily mean the platform is down. Check independent monitoring below for an outside view.</p></div></div></div>}
-      {status.phase === 'ready' && <div className={`mt-4 rounded-2xl border p-6 ${STATE_STYLE[status.overall]}`}><div className="flex items-start gap-4"><span aria-hidden="true" className="flex h-11 w-11 shrink-0 items-center justify-center rounded-full border border-current text-xl font-bold">{ICONS[status.overall]}</span><div><h3 className="text-2xl font-semibold text-white" aria-live="polite" aria-atomic="true">{statusHeadline(status.overall)}</h3><p className="mt-2 leading-7 text-slate-200">{DETAILS[status.overall]}</p><div className="mt-3"><Freshness status={status} /></div>{status.stale && <p className="mt-3 font-semibold text-amber-100" role="status">Unable to refresh. Showing the last known status; it may be out of date.</p>}{status.isRefreshing && <p className="mt-3 text-sm text-slate-300" role="status">Refreshing status…</p>}</div></div></div>}
+      {status.phase === 'ready' && <div className={`mt-4 rounded-2xl border p-6 ${statusStyle}`}><div className="flex items-start gap-4"><span aria-hidden="true" className="flex h-11 w-11 shrink-0 items-center justify-center rounded-full border border-current text-xl font-bold">{statusIcon}</span><div><h3 className="text-2xl font-semibold text-white" aria-live="polite" aria-atomic="true">{headline}</h3><p className="mt-2 leading-7 text-slate-200">{detail}</p><div className="mt-3"><Freshness status={status} /></div>{status.stale && <p className="mt-3 font-semibold text-amber-100" role="status">{staleNotice}</p>}{status.isRefreshing && <p className="mt-3 text-sm text-slate-300" role="status">Refreshing status…</p>}</div></div></div>}
     </section>
 
-    {status.phase === 'ready' && <section className="mt-10" aria-labelledby="services-status"><h2 id="services-status" className="text-2xl font-semibold text-white">Services</h2><p className="mt-2 text-slate-300">Health is grouped by the CK Conflux features people use.</p><ul className="mt-5 grid gap-3 sm:grid-cols-2">{status.components.map((component) => {
+    {status.phase === 'ready' && status.components.length > 0 && <section className="mt-10" aria-labelledby="services-status"><h2 id="services-status" className="text-2xl font-semibold text-white">Services</h2><p className="mt-2 text-slate-300">Health is grouped by the CK Conflux features people use.</p><ul className="mt-5 grid gap-3 sm:grid-cols-2">{status.components.map((component) => {
       const affected = component.state === 'degraded' || component.state === 'unavailable';
       return <li key={component.id} className={`rounded-xl border p-4 ${affected ? STATE_STYLE[component.state] : 'border-white/10 bg-white/5'}`}><div className="flex items-center justify-between gap-4"><span className="font-medium text-white">{component.name}</span><strong className="flex items-center gap-2 text-sm text-white"><span aria-hidden="true">{ICONS[component.state]}</span>{stateLabel(component.state)}</strong></div>{affected && <p className="mt-3 text-sm leading-6 text-slate-200">{IMPACT[component.id] || 'This service may not work normally.'}</p>}</li>;
     })}</ul></section>}

--- a/src/pages/Status.test.jsx
+++ b/src/pages/Status.test.jsx
@@ -67,4 +67,14 @@ describe('Status page', () => {
     expect(screen.queryByRole('heading', { name: "We couldn't retrieve CK Conflux service health" })).not.toBeInTheDocument();
     expect(screen.getByRole('status')).toHaveTextContent('Current platform health could not be confirmed.');
   });
+
+  it('uses neutral incomplete wording when only the feed-level state is unknown', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(response({ status: 'unknown', checks: { website: 'ok' } })));
+    render(<Status />);
+
+    expect(await screen.findByRole('heading', { name: 'Status information incomplete' })).toBeInTheDocument();
+    expect(screen.getByText('Status information is incomplete; the status feed did not confirm a complete platform state.')).toBeInTheDocument();
+    expect(screen.queryByText('Some service checks returned an unknown state.')).not.toBeInTheDocument();
+    expect(screen.getByText('Website').closest('li')).toHaveTextContent('Operational');
+  });
 });

--- a/src/pages/Status.test.jsx
+++ b/src/pages/Status.test.jsx
@@ -1,0 +1,26 @@
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import Status from './Status';
+
+const response = (body) => ({ ok: true, json: async () => body });
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+describe('Status page', () => {
+  it('does not claim absent services are healthy for a partial operational feed', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(response({ checks: { matrix: 'ok', login: 'ok' } })));
+    render(<Status />);
+
+    expect(await screen.findByRole('heading', { name: 'All systems operational' })).toBeInTheDocument();
+    expect(screen.getByText('All reported services are healthy.')).toBeInTheDocument();
+    expect(screen.queryByText('Messaging, sign-in, calls, media, and account services are reporting healthy.')).not.toBeInTheDocument();
+    expect(screen.getByText('Messaging')).toBeInTheDocument();
+    expect(screen.getByText('Sign in')).toBeInTheDocument();
+    expect(screen.queryByText('Voice & video')).not.toBeInTheDocument();
+    expect(screen.queryByText('Media & uploads')).not.toBeInTheDocument();
+    expect(screen.queryByText('Account & membership')).not.toBeInTheDocument();
+  });
+});

--- a/src/pages/Status.test.jsx
+++ b/src/pages/Status.test.jsx
@@ -2,7 +2,7 @@ import { cleanup, render, screen } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import Status from './Status';
 
-const response = (body) => ({ ok: true, json: async () => body });
+const response = (body, ok = true, status = 200) => ({ ok, status, json: async () => body });
 
 afterEach(() => {
   cleanup();
@@ -22,5 +22,49 @@ describe('Status page', () => {
     expect(screen.queryByText('Voice & video')).not.toBeInTheDocument();
     expect(screen.queryByText('Media & uploads')).not.toBeInTheDocument();
     expect(screen.queryByText('Account & membership')).not.toBeInTheDocument();
+  });
+
+  it('renders a stale healthy 503 as stale rather than all systems operational', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(response({
+      status: 'ok',
+      generated_at: '2026-08-30T18:00:00Z',
+      snapshot_age_seconds: 130.1,
+      stale: true,
+      messages: [],
+      checks: {
+        website: 'ok',
+        login: 'ok',
+        matrix: 'ok',
+        media: 'ok',
+        calls: 'ok',
+        membership: 'ok',
+      },
+    }, false, 503)));
+
+    render(<Status />);
+
+    expect(await screen.findByRole('heading', { name: 'Status information may be out of date' })).toBeInTheDocument();
+    expect(screen.queryByRole('heading', { name: 'All systems operational' })).not.toBeInTheDocument();
+    expect(screen.getByRole('status')).toHaveTextContent('Status snapshot is stale. Showing the last known status; it may be out of date.');
+    expect(screen.getByRole('heading', { name: 'Services' })).toBeInTheDocument();
+  });
+
+  it('renders the structured no-snapshot startup response without treating it as malformed', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(response({
+      status: 'unknown',
+      generated_at: null,
+      snapshot_age_seconds: null,
+      stale: true,
+      messages: ['Status snapshot is not yet available'],
+      checks: {},
+    }, false, 503)));
+
+    render(<Status />);
+
+    expect(await screen.findByRole('heading', { name: 'Status snapshot unavailable' })).toBeInTheDocument();
+    expect(screen.getByText(/has not produced a status snapshot yet/i)).toBeInTheDocument();
+    expect(screen.queryByRole('heading', { name: 'Services' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('heading', { name: "We couldn't retrieve CK Conflux service health" })).not.toBeInTheDocument();
+    expect(screen.getByRole('status')).toHaveTextContent('Current platform health could not be confirmed.');
   });
 });

--- a/src/status/status.js
+++ b/src/status/status.js
@@ -11,6 +11,7 @@ const ALIASES = Object.entries(COMPONENTS)
   .flatMap(([id, component]) => component.aliases.map((alias) => ({ alias, id })))
   .sort((a, b) => b.alias.length - a.alias.length);
 const STATE_PRIORITY = { operational: 0, unknown: 1, degraded: 2, unavailable: 3 };
+const CONTRACT_STATES = new Set(['ok', 'degraded', 'down', 'unknown']);
 
 export const STATUS_ENDPOINT = '/status.json';
 export const INDEPENDENT_STATUS_URL = 'https://status.ckconflux.com';
@@ -51,17 +52,31 @@ function overallState(states) {
   return states.reduce((worst, state) => STATE_PRIORITY[state] > STATE_PRIORITY[worst] ? state : worst, 'operational');
 }
 
+function isCurrentContractPayload(payload) {
+  const rawStatus = typeof payload.status === 'string' ? payload.status.toLowerCase().trim() : null;
+  return Boolean(
+    payload.checks
+    && typeof payload.checks === 'object'
+    && !Array.isArray(payload.checks)
+    && typeof payload.stale === 'boolean'
+    && rawStatus
+    && CONTRACT_STATES.has(rawStatus),
+  );
+}
+
 export function parseStatus(payload) {
   if (!payload || typeof payload !== 'object' || Array.isArray(payload)) return null;
+  const currentContract = isCurrentContractPayload(payload);
   const explicitSource = payload.components ?? payload.services ?? payload.checks;
   const source = explicitSource ?? Object.fromEntries(
     Object.entries(payload).filter(([key]) => canonicalComponent(key)),
   );
-  if (!source || (typeof source !== 'object') || (Array.isArray(source) && source.length === 0)) return null;
+  if (!source || typeof source !== 'object') return null;
+
   const entries = Array.isArray(source)
     ? source.map((item) => [item?.name ?? item?.component ?? item?.id, item])
     : Object.entries(source);
-  if (!entries.length) return null;
+  if (!entries.length && !currentContract) return null;
 
   const byId = new Map();
   entries.forEach(([key, value]) => {
@@ -73,13 +88,28 @@ export function parseStatus(payload) {
   const components = [...byId.values()]
     .sort((a, b) => a.order - b.order || a.name.localeCompare(b.name))
     .map(({ id, name, state }) => ({ id, name, state }));
-  if (!components.length) return null;
+
   const generatedAt = payload.generatedAt ?? payload.generated_at ?? payload.updatedAt ?? payload.updated_at ?? payload.timestamp ?? null;
   const states = components.map(({ state }) => state);
   const feedStateValue = payload.status ?? payload.state ?? payload.health;
   if (feedStateValue !== undefined && feedStateValue !== null) states.push(healthState(feedStateValue));
   const overall = overallState(states);
-  return { overall, components, generatedAt };
+  const snapshotAgeValue = payload.snapshotAgeSeconds ?? payload.snapshot_age_seconds;
+  const snapshotAgeSeconds = typeof snapshotAgeValue === 'number' && Number.isFinite(snapshotAgeValue) && snapshotAgeValue >= 0
+    ? snapshotAgeValue
+    : null;
+  const messages = Array.isArray(payload.messages)
+    ? payload.messages.filter((message) => typeof message === 'string' && message.trim()).map((message) => message.trim())
+    : [];
+
+  return {
+    overall,
+    components,
+    generatedAt,
+    snapshotAgeSeconds,
+    stale: payload.stale === true,
+    messages,
+  };
 }
 
 export const stateLabel = (state) => ({ operational: 'Operational', degraded: 'Degraded', unavailable: 'Unavailable', unknown: 'Unknown' }[state] ?? 'Unknown');

--- a/src/status/status.js
+++ b/src/status/status.js
@@ -1,14 +1,16 @@
-const COMPONENT_LABELS = {
-  website: 'Website', web: 'Website', frontend: 'Website',
-  authentication: 'Sign-in / authentication', auth: 'Sign-in / authentication', signin: 'Sign-in / authentication', login: 'Sign-in / authentication',
-  matrix: 'Matrix messaging', messaging: 'Matrix messaging', homeserver: 'Matrix messaging', synapse: 'Matrix messaging',
-  media: 'Media uploads', uploads: 'Media uploads',
-  calls: 'Voice / video calls', call: 'Voice / video calls', matrixrtc: 'Voice / video calls', livekit: 'Voice / video calls',
-  membership: 'Membership / account services', account: 'Membership / account services', accounts: 'Membership / account services',
-  teamspeak: 'TeamSpeak',
+const COMPONENTS = {
+  messaging: { name: 'Messaging', order: 1, aliases: ['matrix', 'messaging', 'homeserver', 'synapse'] },
+  signin: { name: 'Sign in', order: 2, aliases: ['authentication', 'auth', 'signin', 'login'] },
+  calls: { name: 'Voice & video', order: 3, aliases: ['calls', 'call', 'matrixrtc', 'livekit', 'turnify'] },
+  media: { name: 'Media & uploads', order: 4, aliases: ['media', 'uploads'] },
+  account: { name: 'Account & membership', order: 5, aliases: ['membership', 'account', 'accounts'] },
+  website: { name: 'Website', order: 6, aliases: ['website', 'web', 'frontend'] },
 };
 
-const COMPONENT_ALIASES = Object.keys(COMPONENT_LABELS).sort((a, b) => b.length - a.length);
+const ALIASES = Object.entries(COMPONENTS)
+  .flatMap(([id, component]) => component.aliases.map((alias) => ({ alias, id })))
+  .sort((a, b) => b.alias.length - a.alias.length);
+const STATE_PRIORITY = { unknown: 0, operational: 1, degraded: 2, unavailable: 3 };
 
 export const STATUS_ENDPOINT = '/status.json';
 export const INDEPENDENT_STATUS_URL = 'https://status.ckconflux.com';
@@ -27,35 +29,49 @@ export function healthState(value) {
   return 'unknown';
 }
 
-function componentName(key) {
+function normalizeComponent(key) {
   const raw = String(key ?? '').trim();
   const normalized = raw.toLowerCase().replace(/[^a-z0-9]/g, '');
-  const matchingKey = COMPONENT_LABELS[normalized]
-    ? normalized
-    : COMPONENT_ALIASES.find((candidate) => normalized.includes(candidate));
-  if (matchingKey) return COMPONENT_LABELS[matchingKey];
-  if (!raw) return 'Unknown component';
-  return raw
-    .replace(/[_-]+/g, ' ')
-    .replace(/([a-z0-9])([A-Z])/g, '$1 $2')
-    .replace(/\b\w/g, (letter) => letter.toUpperCase());
+  const match = ALIASES.find(({ alias }) => normalized === alias || normalized.includes(alias));
+  if (match) return { id: match.id, name: COMPONENTS[match.id].name, order: COMPONENTS[match.id].order };
+  const infrastructureName = /(kubernetes|deployment|namespace|\bpod\b|worker|internal)/i.test(raw);
+  const name = infrastructureName ? 'Additional service' : raw
+    ? raw.replace(/[_-]+/g, ' ').replace(/([a-z0-9])([A-Z])/g, '$1 $2').replace(/\b\w/g, (letter) => letter.toUpperCase())
+    : 'Unknown component';
+  return { id: `other-${normalized || 'unknown'}`, name, order: 100 };
 }
 
 export function parseStatus(payload) {
   if (!payload || typeof payload !== 'object' || Array.isArray(payload)) return null;
   const source = payload.components ?? payload.services ?? payload.checks;
-  const hasComponentContainer = Array.isArray(source) || (source && typeof source === 'object');
+  if (!source || (typeof source !== 'object') || (Array.isArray(source) && source.length === 0)) return null;
   const entries = Array.isArray(source)
     ? source.map((item) => [item?.name ?? item?.component ?? item?.id, item])
-    : source && typeof source === 'object' ? Object.entries(source) : Object.entries(payload);
-  const components = entries.map(([key, value]) => ({ name: componentName(key), state: healthState(value) }));
-  if (!hasComponentContainer && components.every(({ state }) => state === 'unknown')) return null;
-  const unique = [...new Map(components.map((component) => [component.name, component])).values()];
-  if (!unique.length) return null;
+    : Object.entries(source);
+  if (!entries.length) return null;
+
+  const byId = new Map();
+  entries.forEach(([key, value]) => {
+    const component = normalizeComponent(key);
+    const next = { id: component.id, name: component.name, state: healthState(value), order: component.order };
+    const current = byId.get(component.id);
+    if (!current || STATE_PRIORITY[next.state] > STATE_PRIORITY[current.state]) byId.set(component.id, next);
+  });
+  const components = [...byId.values()]
+    .sort((a, b) => a.order - b.order || a.name.localeCompare(b.name))
+    .map(({ id, name, state }) => ({ id, name, state }));
+  if (!components.length) return null;
   const generatedAt = payload.generatedAt ?? payload.generated_at ?? payload.updatedAt ?? payload.updated_at ?? payload.timestamp ?? null;
-  const states = unique.map(({ state }) => state);
+  const states = components.map(({ state }) => state);
   const overall = states.includes('unavailable') ? 'unavailable' : states.includes('degraded') ? 'degraded' : states.every((state) => state === 'operational') ? 'operational' : 'unknown';
-  return { overall, components: unique, generatedAt };
+  return { overall, components, generatedAt };
 }
 
 export const stateLabel = (state) => ({ operational: 'Operational', degraded: 'Degraded', unavailable: 'Unavailable', unknown: 'Unknown' }[state] ?? 'Unknown');
+
+export const statusHeadline = (state) => ({
+  operational: 'All systems operational',
+  degraded: 'Some services are degraded',
+  unavailable: 'Service outage detected',
+  unknown: 'Status information incomplete',
+}[state] ?? 'Status information incomplete');

--- a/src/status/status.js
+++ b/src/status/status.js
@@ -12,6 +12,10 @@ const ALIASES = Object.entries(COMPONENTS)
   .sort((a, b) => b.alias.length - a.alias.length);
 const STATE_PRIORITY = { operational: 0, unknown: 1, degraded: 2, unavailable: 3 };
 const CONTRACT_STATES = new Set(['ok', 'degraded', 'down', 'unknown']);
+const LEGACY_METADATA_KEYS = new Set([
+  'status', 'state', 'health', 'generatedat', 'updatedat', 'timestamp',
+  'snapshotageseconds', 'stale', 'messages', 'message',
+]);
 
 export const STATUS_ENDPOINT = '/status.json';
 export const INDEPENDENT_STATUS_URL = 'https://status.ckconflux.com';
@@ -30,14 +34,24 @@ export function healthState(value) {
   return 'unknown';
 }
 
+function normalizedKey(key) {
+  return String(key ?? '').trim().toLowerCase().replace(/[^a-z0-9]/g, '');
+}
+
 function canonicalComponent(key) {
-  const normalized = String(key ?? '').trim().toLowerCase().replace(/[^a-z0-9]/g, '');
+  const normalized = normalizedKey(key);
   return ALIASES.find(({ alias }) => normalized === alias || normalized.includes(alias)) ?? null;
+}
+
+function isLegacyHealthEntry(key, value) {
+  if (canonicalComponent(key)) return true;
+  if (LEGACY_METADATA_KEYS.has(normalizedKey(key))) return false;
+  return healthState(value) !== 'unknown';
 }
 
 function normalizeComponent(key) {
   const raw = String(key ?? '').trim();
-  const normalized = raw.toLowerCase().replace(/[^a-z0-9]/g, '');
+  const normalized = normalizedKey(raw);
   const match = canonicalComponent(raw);
   if (match) return { id: match.id, name: COMPONENTS[match.id].name, order: COMPONENTS[match.id].order };
   const infrastructureName = /(kubernetes|deployment|namespace|\bpod\b|worker|internal)/i.test(raw);
@@ -69,7 +83,7 @@ export function parseStatus(payload) {
   const currentContract = isCurrentContractPayload(payload);
   const explicitSource = payload.components ?? payload.services ?? payload.checks;
   const source = explicitSource ?? Object.fromEntries(
-    Object.entries(payload).filter(([key]) => canonicalComponent(key)),
+    Object.entries(payload).filter(([key, value]) => isLegacyHealthEntry(key, value)),
   );
   if (!source || typeof source !== 'object') return null;
 

--- a/src/status/status.js
+++ b/src/status/status.js
@@ -78,9 +78,16 @@ function isCurrentContractPayload(payload) {
   );
 }
 
+function isNoSnapshotPayload(payload) {
+  return isCurrentContractPayload(payload)
+    && payload.status.toLowerCase().trim() === 'unknown'
+    && payload.stale === true
+    && Object.keys(payload.checks).length === 0;
+}
+
 export function parseStatus(payload) {
   if (!payload || typeof payload !== 'object' || Array.isArray(payload)) return null;
-  const currentContract = isCurrentContractPayload(payload);
+  const noSnapshot = isNoSnapshotPayload(payload);
   const explicitSource = payload.components ?? payload.services ?? payload.checks;
   const source = explicitSource ?? Object.fromEntries(
     Object.entries(payload).filter(([key, value]) => isLegacyHealthEntry(key, value)),
@@ -90,7 +97,7 @@ export function parseStatus(payload) {
   const entries = Array.isArray(source)
     ? source.map((item) => [item?.name ?? item?.component ?? item?.id, item])
     : Object.entries(source);
-  if (!entries.length && !currentContract) return null;
+  if (!entries.length && !noSnapshot) return null;
 
   const byId = new Map();
   entries.forEach(([key, value]) => {

--- a/src/status/status.js
+++ b/src/status/status.js
@@ -10,7 +10,7 @@ const COMPONENTS = {
 const ALIASES = Object.entries(COMPONENTS)
   .flatMap(([id, component]) => component.aliases.map((alias) => ({ alias, id })))
   .sort((a, b) => b.alias.length - a.alias.length);
-const STATE_PRIORITY = { unknown: 0, operational: 1, degraded: 2, unavailable: 3 };
+const STATE_PRIORITY = { operational: 0, unknown: 1, degraded: 2, unavailable: 3 };
 
 export const STATUS_ENDPOINT = '/status.json';
 export const INDEPENDENT_STATUS_URL = 'https://status.ckconflux.com';
@@ -29,10 +29,15 @@ export function healthState(value) {
   return 'unknown';
 }
 
+function canonicalComponent(key) {
+  const normalized = String(key ?? '').trim().toLowerCase().replace(/[^a-z0-9]/g, '');
+  return ALIASES.find(({ alias }) => normalized === alias || normalized.includes(alias)) ?? null;
+}
+
 function normalizeComponent(key) {
   const raw = String(key ?? '').trim();
   const normalized = raw.toLowerCase().replace(/[^a-z0-9]/g, '');
-  const match = ALIASES.find(({ alias }) => normalized === alias || normalized.includes(alias));
+  const match = canonicalComponent(raw);
   if (match) return { id: match.id, name: COMPONENTS[match.id].name, order: COMPONENTS[match.id].order };
   const infrastructureName = /(kubernetes|deployment|namespace|\bpod\b|worker|internal)/i.test(raw);
   const name = infrastructureName ? 'Additional service' : raw
@@ -41,9 +46,17 @@ function normalizeComponent(key) {
   return { id: `other-${normalized || 'unknown'}`, name, order: 100 };
 }
 
+function overallState(states) {
+  if (!states.length) return 'unknown';
+  return states.reduce((worst, state) => STATE_PRIORITY[state] > STATE_PRIORITY[worst] ? state : worst, 'operational');
+}
+
 export function parseStatus(payload) {
   if (!payload || typeof payload !== 'object' || Array.isArray(payload)) return null;
-  const source = payload.components ?? payload.services ?? payload.checks;
+  const explicitSource = payload.components ?? payload.services ?? payload.checks;
+  const source = explicitSource ?? Object.fromEntries(
+    Object.entries(payload).filter(([key]) => canonicalComponent(key)),
+  );
   if (!source || (typeof source !== 'object') || (Array.isArray(source) && source.length === 0)) return null;
   const entries = Array.isArray(source)
     ? source.map((item) => [item?.name ?? item?.component ?? item?.id, item])
@@ -63,7 +76,9 @@ export function parseStatus(payload) {
   if (!components.length) return null;
   const generatedAt = payload.generatedAt ?? payload.generated_at ?? payload.updatedAt ?? payload.updated_at ?? payload.timestamp ?? null;
   const states = components.map(({ state }) => state);
-  const overall = states.includes('unavailable') ? 'unavailable' : states.includes('degraded') ? 'degraded' : states.every((state) => state === 'operational') ? 'operational' : 'unknown';
+  const feedStateValue = payload.status ?? payload.state ?? payload.health;
+  if (feedStateValue !== undefined && feedStateValue !== null) states.push(healthState(feedStateValue));
+  const overall = overallState(states);
   return { overall, components, generatedAt };
 }
 

--- a/src/status/status.test.js
+++ b/src/status/status.test.js
@@ -15,6 +15,65 @@ describe('status payload normalization', () => {
     ]);
   });
 
+  it('parses the current GitOps public status contract and freshness metadata', () => {
+    const parsed = parseStatus({
+      status: 'ok',
+      generated_at: '2026-08-30T18:00:00Z',
+      snapshot_age_seconds: 12.4,
+      stale: false,
+      messages: [],
+      checks: {
+        website: 'ok',
+        login: 'ok',
+        matrix: 'ok',
+        media: 'ok',
+        calls: 'ok',
+        membership: 'ok',
+      },
+    });
+
+    expect(parsed.overall).toBe('operational');
+    expect(parsed.stale).toBe(false);
+    expect(parsed.snapshotAgeSeconds).toBe(12.4);
+    expect(parsed.generatedAt).toBe('2026-08-30T18:00:00Z');
+    expect(parsed.components).toHaveLength(6);
+  });
+
+  it('preserves a stale healthy snapshot instead of treating the response as fresh', () => {
+    const parsed = parseStatus({
+      status: 'ok',
+      generated_at: '2026-08-30T18:00:00Z',
+      snapshot_age_seconds: 125.2,
+      stale: true,
+      messages: [],
+      checks: { website: 'ok', login: 'ok', matrix: 'ok', media: 'ok', calls: 'ok', membership: 'ok' },
+    });
+
+    expect(parsed.overall).toBe('operational');
+    expect(parsed.stale).toBe(true);
+    expect(parsed.snapshotAgeSeconds).toBe(125.2);
+  });
+
+  it('accepts the structured startup response before a snapshot exists', () => {
+    const parsed = parseStatus({
+      status: 'unknown',
+      generated_at: null,
+      snapshot_age_seconds: null,
+      stale: true,
+      messages: ['Status snapshot is not yet available'],
+      checks: {},
+    });
+
+    expect(parsed).toMatchObject({
+      overall: 'unknown',
+      components: [],
+      generatedAt: null,
+      snapshotAgeSeconds: null,
+      stale: true,
+      messages: ['Status snapshot is not yet available'],
+    });
+  });
+
   it('aggregates unavailable ahead of degraded', () => {
     expect(parseStatus({ services: { matrix: 'degraded', calls: 'failed' } }).overall).toBe('unavailable');
   });
@@ -46,7 +105,7 @@ describe('status payload normalization', () => {
     expect(parsed.overall).toBe('unknown');
   });
 
-  it('preserves recognized top-level component payloads', () => {
+  it('preserves recognized top-level component payloads for legacy compatibility', () => {
     const parsed = parseStatus({ website: 'up', matrix: 'degraded', generated_at: '2026-08-30T12:00:00Z' });
     expect(parsed.overall).toBe('degraded');
     expect(parsed.generatedAt).toBe('2026-08-30T12:00:00Z');
@@ -56,7 +115,7 @@ describe('status payload normalization', () => {
     ]);
   });
 
-  it('rejects JSON without meaningful component data', () => {
+  it('rejects JSON without meaningful component data or the current structured contract', () => {
     expect(parseStatus({ status: 'degraded', message: 'Synapse degraded' })).toBeNull();
     expect(parseStatus({ checks: {} })).toBeNull();
   });

--- a/src/status/status.test.js
+++ b/src/status/status.test.js
@@ -74,6 +74,18 @@ describe('status payload normalization', () => {
     });
   });
 
+  it('rejects empty completed contract snapshots', () => {
+    expect(parseStatus({
+      status: 'ok',
+      generated_at: '2026-08-30T18:00:00Z',
+      snapshot_age_seconds: 5,
+      stale: false,
+      messages: [],
+      checks: {},
+    })).toBeNull();
+    expect(parseStatus({ status: 'degraded', stale: false, checks: {} })).toBeNull();
+  });
+
   it('aggregates unavailable ahead of degraded', () => {
     expect(parseStatus({ services: { matrix: 'degraded', calls: 'failed' } }).overall).toBe('unavailable');
   });
@@ -140,7 +152,7 @@ describe('status payload normalization', () => {
     expect(parsed.snapshotAgeSeconds).toBe(30);
   });
 
-  it('rejects JSON without meaningful component data or the current structured contract', () => {
+  it('rejects JSON without meaningful component data or the explicit no-snapshot contract', () => {
     expect(parseStatus({ status: 'degraded', message: 'Synapse degraded' })).toBeNull();
     expect(parseStatus({ checks: {} })).toBeNull();
   });

--- a/src/status/status.test.js
+++ b/src/status/status.test.js
@@ -115,6 +115,31 @@ describe('status payload normalization', () => {
     ]);
   });
 
+  it('preserves health-like custom top-level states without treating metadata as components', () => {
+    const parsed = parseStatus({
+      website: 'up',
+      bridgeService: 'down',
+      generated_at: '2026-08-30T12:00:00Z',
+      snapshot_age_seconds: 30,
+      stale: true,
+      messages: ['Legacy payload'],
+    });
+
+    expect(parsed.overall).toBe('unavailable');
+    expect(parsed.components).toEqual([
+      { id: 'website', name: 'Website', state: 'operational' },
+      { id: 'other-bridgeservice', name: 'Bridge Service', state: 'unavailable' },
+    ]);
+    expect(parsed.components.map(({ id }) => id)).not.toEqual(expect.arrayContaining([
+      'other-stale',
+      'other-snapshotageseconds',
+      'other-generatedat',
+      'other-messages',
+    ]));
+    expect(parsed.stale).toBe(true);
+    expect(parsed.snapshotAgeSeconds).toBe(30);
+  });
+
   it('rejects JSON without meaningful component data or the current structured contract', () => {
     expect(parseStatus({ status: 'degraded', message: 'Synapse degraded' })).toBeNull();
     expect(parseStatus({ checks: {} })).toBeNull();

--- a/src/status/status.test.js
+++ b/src/status/status.test.js
@@ -19,6 +19,16 @@ describe('status payload normalization', () => {
     expect(parseStatus({ services: { matrix: 'degraded', calls: 'failed' } }).overall).toBe('unavailable');
   });
 
+  it('honors an explicit feed-level outage over healthy component entries', () => {
+    const parsed = parseStatus({ status: 'unavailable', checks: { website: 'ok', matrix: 'ok' } });
+    expect(parsed.overall).toBe('unavailable');
+  });
+
+  it('keeps an explicit feed-level degraded state without escalating it to unavailable', () => {
+    const parsed = parseStatus({ status: 'degraded', checks: { website: 'ok', matrix: 'ok' } });
+    expect(parsed.overall).toBe('degraded');
+  });
+
   it('includes unknown future components safely instead of dropping them', () => {
     const parsed = parseStatus({ components: { website: 'up', bridgeService: 'mystery' } });
     expect(parsed.overall).toBe('unknown');
@@ -28,6 +38,22 @@ describe('status payload normalization', () => {
   it('uses the least healthy state when aliases describe the same category', () => {
     const parsed = parseStatus({ checks: { login: 'ok', authentication: 'down' } });
     expect(parsed.components).toEqual([{ id: 'signin', name: 'Sign in', state: 'unavailable' }]);
+  });
+
+  it('keeps an unknown alias result ahead of an operational alias result', () => {
+    const parsed = parseStatus({ checks: { matrix: 'ok', synapse: 'mystery' } });
+    expect(parsed.components).toEqual([{ id: 'messaging', name: 'Messaging', state: 'unknown' }]);
+    expect(parsed.overall).toBe('unknown');
+  });
+
+  it('preserves recognized top-level component payloads', () => {
+    const parsed = parseStatus({ website: 'up', matrix: 'degraded', generated_at: '2026-08-30T12:00:00Z' });
+    expect(parsed.overall).toBe('degraded');
+    expect(parsed.generatedAt).toBe('2026-08-30T12:00:00Z');
+    expect(parsed.components).toEqual([
+      { id: 'messaging', name: 'Messaging', state: 'degraded' },
+      { id: 'website', name: 'Website', state: 'operational' },
+    ]);
   });
 
   it('rejects JSON without meaningful component data', () => {

--- a/src/status/status.test.js
+++ b/src/status/status.test.js
@@ -2,45 +2,36 @@ import { describe, expect, it } from 'vitest';
 import { parseStatus } from './status';
 
 describe('status payload normalization', () => {
-  it('keeps Matrix messaging and MatrixRTC call health distinct', () => {
-    const parsed = parseStatus({
-      components: {
-        matrix: 'up',
-        matrixrtc: 'degraded',
-      },
-    });
-
+  it('normalizes labels, keeps messaging and calls distinct, and uses preferred order', () => {
+    const parsed = parseStatus({ components: { website: 'up', matrixrtc: 'degraded', login: 'ok', matrix: 'up', media: 'healthy', membership: 'passing' } });
     expect(parsed.overall).toBe('degraded');
     expect(parsed.components).toEqual([
-      { name: 'Matrix messaging', state: 'operational' },
-      { name: 'Voice / video calls', state: 'degraded' },
+      { id: 'messaging', name: 'Messaging', state: 'operational' },
+      { id: 'signin', name: 'Sign in', state: 'operational' },
+      { id: 'calls', name: 'Voice & video', state: 'degraded' },
+      { id: 'media', name: 'Media & uploads', state: 'operational' },
+      { id: 'account', name: 'Account & membership', state: 'operational' },
+      { id: 'website', name: 'Website', state: 'operational' },
     ]);
   });
 
-  it('includes unknown components in the aggregate instead of dropping them', () => {
-    const parsed = parseStatus({
-      components: {
-        website: 'up',
-        bridgeService: 'down',
-      },
-    });
-
-    expect(parsed.overall).toBe('unavailable');
-    expect(parsed.components).toContainEqual({ name: 'Bridge Service', state: 'unavailable' });
+  it('aggregates unavailable ahead of degraded', () => {
+    expect(parseStatus({ services: { matrix: 'degraded', calls: 'failed' } }).overall).toBe('unavailable');
   });
 
-  it('normalizes the production login check and TeamSpeak component', () => {
-    const parsed = parseStatus({
-      checks: {
-        login: 'ok',
-        teamspeak: 'degraded',
-      },
-    });
+  it('includes unknown future components safely instead of dropping them', () => {
+    const parsed = parseStatus({ components: { website: 'up', bridgeService: 'mystery' } });
+    expect(parsed.overall).toBe('unknown');
+    expect(parsed.components).toContainEqual({ id: 'other-bridgeservice', name: 'Bridge Service', state: 'unknown' });
+  });
 
-    expect(parsed.overall).toBe('degraded');
-    expect(parsed.components).toEqual([
-      { name: 'Sign-in / authentication', state: 'operational' },
-      { name: 'TeamSpeak', state: 'degraded' },
-    ]);
+  it('uses the least healthy state when aliases describe the same category', () => {
+    const parsed = parseStatus({ checks: { login: 'ok', authentication: 'down' } });
+    expect(parsed.components).toEqual([{ id: 'signin', name: 'Sign in', state: 'unavailable' }]);
+  });
+
+  it('rejects JSON without meaningful component data', () => {
+    expect(parseStatus({ status: 'degraded', message: 'Synapse degraded' })).toBeNull();
+    expect(parseStatus({ checks: {} })).toBeNull();
   });
 });

--- a/src/status/useLocalStatus.js
+++ b/src/status/useLocalStatus.js
@@ -1,7 +1,18 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { parseStatus, STATUS_ENDPOINT } from './status';
 
-const EMPTY_RESULT = { phase: 'loading', overall: 'unknown', components: [], generatedAt: null, checkedAt: null, isRefreshing: false, stale: false, refreshError: false };
+const EMPTY_RESULT = {
+  phase: 'loading',
+  overall: 'unknown',
+  components: [],
+  generatedAt: null,
+  snapshotAgeSeconds: null,
+  messages: [],
+  checkedAt: null,
+  isRefreshing: false,
+  stale: false,
+  refreshError: false,
+};
 
 export function useLocalStatus({ refreshIntervalMs = 0, timeoutMs = 8000 } = {}) {
   const [result, setResult] = useState(EMPTY_RESULT);
@@ -19,7 +30,13 @@ export function useLocalStatus({ refreshIntervalMs = 0, timeoutMs = 8000 } = {})
       const parsed = parseStatus(await response.json());
       if (!parsed) throw new Error('Unrecognized status payload');
       if (mounted.current && activeController.current === controller) {
-        setResult({ phase: 'ready', ...parsed, checkedAt: new Date().toISOString(), isRefreshing: false, stale: false, refreshError: false });
+        setResult({
+          phase: 'ready',
+          ...parsed,
+          checkedAt: new Date().toISOString(),
+          isRefreshing: false,
+          refreshError: false,
+        });
       }
     } catch {
       if (mounted.current && activeController.current === controller) {

--- a/src/status/useLocalStatus.js
+++ b/src/status/useLocalStatus.js
@@ -1,21 +1,47 @@
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { parseStatus, STATUS_ENDPOINT } from './status';
 
-export function useLocalStatus() {
-  const [result, setResult] = useState({ phase: 'loading', overall: 'unknown', components: [], generatedAt: null });
-  useEffect(() => {
+const EMPTY_RESULT = { phase: 'loading', overall: 'unknown', components: [], generatedAt: null, checkedAt: null, isRefreshing: false, stale: false, refreshError: false };
+
+export function useLocalStatus({ refreshIntervalMs = 0, timeoutMs = 8000 } = {}) {
+  const [result, setResult] = useState(EMPTY_RESULT);
+  const mounted = useRef(false);
+  const activeController = useRef(null);
+
+  const refresh = useCallback(async () => {
+    activeController.current?.abort();
     const controller = new AbortController();
-    let mounted = true;
-    const timer = setTimeout(() => { controller.abort(); if (mounted) setResult({ phase: 'error', overall: 'unknown', components: [], generatedAt: null }); }, 8000);
-    fetch(STATUS_ENDPOINT, { signal: controller.signal, headers: { Accept: 'application/json' } })
-      .then((response) => { if (!response.ok) throw new Error('Status request failed'); return response.json(); })
-      .then((payload) => {
-        const parsed = parseStatus(payload);
-        setResult(parsed ? { phase: 'ready', ...parsed } : { phase: 'error', overall: 'unknown', components: [], generatedAt: null });
-      })
-      .catch(() => { if (mounted && !controller.signal.aborted) setResult({ phase: 'error', overall: 'unknown', components: [], generatedAt: null }); })
-      .finally(() => clearTimeout(timer));
-    return () => { mounted = false; clearTimeout(timer); controller.abort(); };
-  }, []);
-  return result;
+    activeController.current = controller;
+    setResult((current) => current.phase === 'ready' ? { ...current, isRefreshing: true } : { ...EMPTY_RESULT });
+    const timeout = setTimeout(() => controller.abort(), timeoutMs);
+    try {
+      const response = await fetch(STATUS_ENDPOINT, { signal: controller.signal, headers: { Accept: 'application/json' } });
+      const parsed = parseStatus(await response.json());
+      if (!parsed) throw new Error('Unrecognized status payload');
+      if (mounted.current && activeController.current === controller) {
+        setResult({ phase: 'ready', ...parsed, checkedAt: new Date().toISOString(), isRefreshing: false, stale: false, refreshError: false });
+      }
+    } catch {
+      if (mounted.current && activeController.current === controller) {
+        setResult((current) => current.phase === 'ready'
+          ? { ...current, isRefreshing: false, stale: true, refreshError: true }
+          : { ...EMPTY_RESULT, phase: 'error', refreshError: true });
+      }
+    } finally {
+      clearTimeout(timeout);
+    }
+  }, [timeoutMs]);
+
+  useEffect(() => {
+    mounted.current = true;
+    refresh();
+    const interval = refreshIntervalMs > 0 ? setInterval(refresh, refreshIntervalMs) : null;
+    return () => {
+      mounted.current = false;
+      activeController.current?.abort();
+      if (interval) clearInterval(interval);
+    };
+  }, [refresh, refreshIntervalMs]);
+
+  return { ...result, refresh };
 }

--- a/src/status/useLocalStatus.test.jsx
+++ b/src/status/useLocalStatus.test.jsx
@@ -23,6 +23,13 @@ describe('useLocalStatus', () => {
     expect(result.current.overall).toBe(overall);
   });
 
+  it('honors an explicit feed-level outage even when component checks are healthy', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(response({ status: 'unavailable', checks: { website: 'ok', matrix: 'ok' } }, false)));
+    const { result } = renderHook(() => useLocalStatus());
+    await waitFor(() => expect(result.current.phase).toBe('ready'));
+    expect(result.current.overall).toBe('unavailable');
+  });
+
   it.each([
     ['malformed JSON', () => Promise.resolve({ ok: true, json: () => Promise.reject(new SyntaxError()) })],
     ['unrecognized JSON', () => Promise.resolve(response({ status: 'down', error: 'backend error' }, false))],

--- a/src/status/useLocalStatus.test.jsx
+++ b/src/status/useLocalStatus.test.jsx
@@ -30,6 +30,39 @@ describe('useLocalStatus', () => {
     expect(result.current.overall).toBe('unavailable');
   });
 
+  it('preserves the current contract stale flag on an HTTP 503 healthy snapshot', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(response({
+      status: 'ok',
+      generated_at: '2026-08-30T12:00:00Z',
+      snapshot_age_seconds: 130.5,
+      stale: true,
+      messages: [],
+      checks: { website: 'ok', login: 'ok', matrix: 'ok', media: 'ok', calls: 'ok', membership: 'ok' },
+    }, false)));
+    const { result } = renderHook(() => useLocalStatus());
+    await waitFor(() => expect(result.current.phase).toBe('ready'));
+    expect(result.current.overall).toBe('operational');
+    expect(result.current.stale).toBe(true);
+    expect(result.current.snapshotAgeSeconds).toBe(130.5);
+    expect(result.current.refreshError).toBe(false);
+  });
+
+  it('accepts the structured unavailable startup snapshot as status data', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(response({
+      status: 'unknown',
+      generated_at: null,
+      snapshot_age_seconds: null,
+      stale: true,
+      messages: ['Status snapshot is not yet available'],
+      checks: {},
+    }, false)));
+    const { result } = renderHook(() => useLocalStatus());
+    await waitFor(() => expect(result.current.phase).toBe('ready'));
+    expect(result.current.overall).toBe('unknown');
+    expect(result.current.stale).toBe(true);
+    expect(result.current.components).toEqual([]);
+  });
+
   it.each([
     ['malformed JSON', () => Promise.resolve({ ok: true, json: () => Promise.reject(new SyntaxError()) })],
     ['unrecognized JSON', () => Promise.resolve(response({ status: 'down', error: 'backend error' }, false))],

--- a/src/status/useLocalStatus.test.jsx
+++ b/src/status/useLocalStatus.test.jsx
@@ -1,0 +1,71 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { useLocalStatus } from './useLocalStatus';
+
+const payload = (state = 'ok') => ({ generated_at: '2026-08-30T12:00:00Z', checks: { matrix: state } });
+const response = (body, ok = true) => ({ ok, json: async () => body });
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+});
+
+describe('useLocalStatus', () => {
+  it.each([
+    [200, 'ok', 'operational'],
+    [503, 'degraded', 'degraded'],
+    [503, 'down', 'unavailable'],
+    [418, 'degraded', 'degraded'],
+  ])('accepts a recognized payload from HTTP %s', async (code, state, overall) => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(response(payload(state), code < 400)));
+    const { result } = renderHook(() => useLocalStatus());
+    await waitFor(() => expect(result.current.phase).toBe('ready'));
+    expect(result.current.overall).toBe(overall);
+  });
+
+  it.each([
+    ['malformed JSON', () => Promise.resolve({ ok: true, json: () => Promise.reject(new SyntaxError()) })],
+    ['unrecognized JSON', () => Promise.resolve(response({ status: 'down', error: 'backend error' }, false))],
+    ['network failure', () => Promise.reject(new TypeError('offline'))],
+  ])('reports %s as an error', async (_label, implementation) => {
+    vi.stubGlobal('fetch', vi.fn().mockImplementation(implementation));
+    const { result } = renderHook(() => useLocalStatus());
+    await waitFor(() => expect(result.current.phase).toBe('error'));
+  });
+
+  it('reports a timeout as an error', async () => {
+    vi.useFakeTimers();
+    vi.stubGlobal('fetch', vi.fn((_url, { signal }) => new Promise((_resolve, reject) => signal.addEventListener('abort', () => reject(new DOMException('Aborted', 'AbortError'))))));
+    const { result } = renderHook(() => useLocalStatus({ timeoutMs: 50 }));
+    await act(async () => { await vi.advanceTimersByTimeAsync(51); });
+    expect(result.current.phase).toBe('error');
+  });
+
+  it('keeps successful data visible during refresh and marks it stale after failure', async () => {
+    let rejectRefresh;
+    const fetch = vi.fn()
+      .mockResolvedValueOnce(response(payload()))
+      .mockImplementationOnce(() => new Promise((_resolve, reject) => { rejectRefresh = reject; }));
+    vi.stubGlobal('fetch', fetch);
+    const { result } = renderHook(() => useLocalStatus());
+    await waitFor(() => expect(result.current.phase).toBe('ready'));
+    act(() => { result.current.refresh(); });
+    expect(result.current.phase).toBe('ready');
+    expect(result.current.isRefreshing).toBe(true);
+    expect(result.current.components[0].name).toBe('Messaging');
+    await act(async () => { rejectRefresh(new Error('offline')); });
+    expect(result.current.phase).toBe('ready');
+    expect(result.current.stale).toBe(true);
+    expect(result.current.refreshError).toBe(true);
+    expect(fetch).toHaveBeenCalledTimes(2);
+  });
+
+  it('manual refresh performs another successful request', async () => {
+    const fetch = vi.fn().mockResolvedValue(response(payload()));
+    vi.stubGlobal('fetch', fetch);
+    const { result } = renderHook(() => useLocalStatus());
+    await waitFor(() => expect(result.current.phase).toBe('ready'));
+    await act(async () => { await result.current.refresh(); });
+    expect(fetch).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
### Motivation

- Fix a critical correctness bug where the client treated any non-2xx response as a request failure instead of accepting valid `/status.json` payloads.
- Align the client with the current GitOps public status contract from `ck-conflux-apps-gitops` main (`5d6c3457`), where HTTP `503` is used for degraded/down states **and** for stale/unavailable snapshots.
- Rework the status page UX so the primary hierarchy is CK Conflux-first: overall platform status, user-facing services and impacts, freshness, then independent monitoring as a secondary/outside-in fallback.
- Make the status hook resilient to malformed/timeout/network failures while preserving last-known good data during refreshes and surfacing stale/refresh-error state when appropriate.

### Current status contract

The client now consumes the producer's structured fields:

- `status`: `ok | degraded | down | unknown`
- `generated_at`: snapshot generation time or `null`
- `snapshot_age_seconds`: snapshot age or `null`
- `stale`: authoritative snapshot freshness flag
- `messages`: user-facing status messages
- `checks`: the six public categories `website`, `login`, `matrix`, `media`, `calls`, and `membership`

Behavior is aligned with GitOps:

- HTTP `200` is expected only when `status=ok` and the snapshot is fresh.
- HTTP `503` payloads are still parsed as status data.
- A stale snapshot can have `status=ok`; the UI therefore does not call stale data live or claim all systems operational.
- The startup/unavailable response (`status=unknown`, `stale=true`, `checks={}`) is treated as structured status data rather than malformed JSON.
- TeamSpeak is intentionally not restored as a public component because it is not part of the current GitOps public contract.

### Description

- Normalize status payloads in `src/status/status.js` with canonical user-facing labels, conservative aggregation, feed-level status handling, and current-contract freshness metadata.
- Preserve `stale`, `snapshot_age_seconds`, and `messages` through `src/status/useLocalStatus.js`; a successful fetch no longer clears a server-reported stale condition.
- Keep manual refresh and optional periodic refresh (`refreshIntervalMs`), timeout handling, and last-known-good data on client/network refresh failures.
- Rework `src/pages/Status.jsx` and `src/components/StatusSummary.jsx` so stale snapshots are explicitly identified, structured no-snapshot startup responses are presented safely, and feed-level outages cannot be weakened by component-specific headlines.
- Keep independent UptimeRobot badge/links using existing centralized constants; do not add UptimeRobot API calls or iframe content.
- Preserve limited legacy parser compatibility without expanding the current public component contract.

### Testing

GitHub CI on the current PR head passed:

- `npm run test:run` — **100 tests passed across 6 test files**.
- `npm run build` — production build and prerender completed successfully.
- `npm run lint` — passed.
- Helm lint/template/kubeconform/chart-testing validation — passed.
- Docker workflow — passed.

Added focused regression coverage for current-contract fresh/stale payloads, the structured startup response, stale healthy HTTP 503 handling, feed-level outage precedence, partial feeds, refresh failures, and homepage/status-page freshness behavior.

No GitOps/Kubernetes manifests, backend `/status.json` implementation, or new runtime dependencies are changed by this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a9461063da8832cb4e3838ca021d1d4)