### PR TITLE
Improve status UX and simplify external status-page treatment

### DIFF
--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -41,13 +41,9 @@ describe('CK Conflux application architecture', () => {
     expect(screen.getAllByRole('link', { name: 'Join CK Conflux' })[0]).toHaveAttribute('href', '/join');
   });
 
-  it('renders the independent service status badge without replacing footer navigation', () => {
+  it('keeps status navigation without a redundant monitoring badge', () => {
     renderPath('/');
-    const badge = screen.getByRole('img', { name: 'CK Conflux service status' });
-    expect(badge).toHaveAttribute('src', 'https://badge.uptimerobot.com/psp/177dfd29052bc6cc25407cf35076378b.svg?style=text&theme=dark');
-    expect(badge.closest('a')).toHaveAttribute('href', 'https://status.ckconflux.com?utm_source=status_badge&utm_medium=referral');
-    expect(badge.closest('a')).toHaveAttribute('target', '_blank');
-    expect(badge.closest('a')).toHaveAttribute('rel', 'noopener noreferrer');
+    expect(screen.queryByRole('img', { name: 'CK Conflux service status' })).not.toBeInTheDocument();
     expect(screen.getByRole('navigation', { name: 'Explore links' })).toHaveTextContent('Status');
     expect(screen.getByRole('navigation', { name: 'Explore links' })).toHaveTextContent('About');
     expect(screen.getByRole('navigation', { name: 'Community links' })).toHaveTextContent('Support');
@@ -415,8 +411,8 @@ describe('CK Conflux application architecture', () => {
     expect(document.querySelector('time')).toHaveAttribute('datetime', '2026-08-26T12:00:00Z');
     expect(screen.getByRole('button', { name: 'Refresh' })).toBeInTheDocument();
     const overall = screen.getByRole('heading', { name: /overall ck conflux status/i });
-    const independent = screen.getByRole('heading', { name: 'Independent monitoring' });
-    expect(overall.compareDocumentPosition(independent) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    const uptime = screen.getByRole('link', { name: /View uptime history/ });
+    expect(overall.compareDocumentPosition(uptime) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
   });
 
   it('renders degraded status without claiming all systems operational', async () => {
@@ -432,13 +428,15 @@ describe('CK Conflux application architecture', () => {
   ])('shows unknown status for a %s', async (_name, response) => {
     fetch.mockImplementation(response);
     renderPath('/status');
-    expect(await screen.findByRole('heading', { name: "We couldn't retrieve CK Conflux service health" })).toBeInTheDocument();
+    expect(await screen.findByRole('heading', { name: 'Status information unavailable' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Retry' })).toBeInTheDocument();
     expect(document.body).not.toHaveTextContent('All systems operational');
   });
 
-  it('prominently links the authoritative independent status host', () => {
+  it('provides one compact link to uptime history', () => {
     renderPath('/status');
-    expect(screen.getByRole('link', { name: /Open independent status page/ })).toHaveAttribute('href', 'https://status.ckconflux.com');
+    expect(screen.getByRole('link', { name: /View uptime history/ })).toHaveAttribute('href', 'https://status.ckconflux.com');
+    expect(screen.queryByText('Independent monitoring')).not.toBeInTheDocument();
     expect(document.body).not.toHaveTextContent('status.colonelkrud.com');
   });
 

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -1,6 +1,5 @@
 import { ExternalLink, SiteLink } from './SiteLink';
 import { ACCOUNT_PORTAL_URL } from '../config/community';
-import { INDEPENDENT_STATUS_BADGE_LINK, INDEPENDENT_STATUS_BADGE_URL } from '../status/status';
 const groups = [
   ['Explore', [['About','/about'],['Join','/join'],['Membership','/membership'],['My Account',ACCOUNT_PORTAL_URL, true],['Security','/security'],['Status','/status']]],
   ['Community', [['Help','/help'],['Support','/support'],['TeamSpeak 6 Beta','/teamspeak']]],
@@ -11,9 +10,6 @@ export default function Footer() {
     <div className="mx-auto grid w-full max-w-6xl gap-8 px-4 py-8 sm:grid-cols-4 sm:px-6 lg:px-8">
       <div>
         <p className="text-sm text-slate-400">CK Conflux community platform</p>
-        <ExternalLink href={INDEPENDENT_STATUS_BADGE_LINK} target="_blank" rel="noopener noreferrer" className="mt-3 inline-block">
-          <img src={INDEPENDENT_STATUS_BADGE_URL} alt="CK Conflux service status" className="h-auto max-w-full" />
-        </ExternalLink>
       </div>
       {groups.map(([heading, links]) => <nav key={heading} aria-label={`${heading} links`}><h2 className="text-sm font-semibold text-white">{heading}</h2><ul className="mt-2 space-y-2 text-sm text-slate-400">{links.map(([label,to,external]) => <li key={to}>{external ? <ExternalLink href={to} className="hover:text-white">{label}</ExternalLink> : <SiteLink to={to} className="hover:text-white">{label}</SiteLink>}</li>)}</ul></nav>)}
     </div>

--- a/src/components/StatusSummary.jsx
+++ b/src/components/StatusSummary.jsx
@@ -60,7 +60,7 @@ export default function StatusSummary() {
     {supporting && <p className="mt-1 text-sm text-slate-300">{supporting}</p>}
     {freshness && <p className="mt-1 text-sm text-slate-400">{freshness}</p>}
     {status.stale && <p className="mt-1 text-sm font-semibold text-amber-100" role="status">{staleNotice}</p>}
-    {status.refreshError && <p className="mt-1 text-sm font-semibold text-amber-100" role="status">Unable to refresh status. Showing the last known update.</p>}
+    {status.phase === 'ready' && status.refreshError && <p className="mt-1 text-sm font-semibold text-amber-100" role="status">Unable to refresh status. Showing the last known update.</p>}
     <Link to="/status" className="mt-3 inline-flex text-sm font-semibold text-cyan-200 hover:text-cyan-100">View details →</Link>
   </div>;
 }

--- a/src/components/StatusSummary.jsx
+++ b/src/components/StatusSummary.jsx
@@ -16,14 +16,14 @@ function relativeUpdateLabel(value) {
 export default function StatusSummary() {
   const status = useLocalStatus({ refreshIntervalMs: 60000 });
   const affected = status.components.filter(({ state }) => state === 'degraded' || state === 'unavailable');
-  const snapshotMissing = status.phase === 'ready' && status.stale && status.components.length === 0 && !status.generatedAt;
+  const snapshotMissing = status.phase === 'ready' && status.noSnapshot;
 
   let message = status.phase === 'loading'
     ? 'Checking service status…'
     : status.phase === 'error'
       ? 'Status is temporarily unavailable'
       : snapshotMissing
-        ? 'Status snapshot unavailable'
+        ? 'Status information unavailable'
         : status.stale
           ? 'Status information may be out of date'
           : statusHeadline(status.overall);
@@ -37,7 +37,7 @@ export default function StatusSummary() {
   let supporting = null;
   if (status.phase === 'ready' && status.stale) {
     supporting = snapshotMissing
-      ? 'CK Conflux has not produced a status snapshot yet.'
+      ? 'Current service status is not available yet.'
       : `Last reported state: ${statusHeadline(status.overall)}.`;
   } else if (status.phase === 'ready' && affected.length === 1) {
     supporting = affected[0].id === 'calls' && messagingOperational && signinOperational
@@ -51,8 +51,8 @@ export default function StatusSummary() {
     ? relativeUpdateLabel(status.generatedAt || (!status.stale ? status.checkedAt : null))
     : null;
   const staleNotice = snapshotMissing
-    ? 'Current platform health could not be confirmed.'
-    : 'Status snapshot is stale. Showing the last known status; it may be out of date.';
+    ? 'A status snapshot is not available yet.'
+    : 'Showing the last reported service status.';
 
   return <div className="min-h-24 rounded-2xl border border-white/10 bg-white/5 p-5">
     <p className="text-xs font-semibold uppercase tracking-[0.18em] text-cyan-200">{status.stale ? 'Service status' : 'Live service status'}</p>
@@ -60,6 +60,7 @@ export default function StatusSummary() {
     {supporting && <p className="mt-1 text-sm text-slate-300">{supporting}</p>}
     {freshness && <p className="mt-1 text-sm text-slate-400">{freshness}</p>}
     {status.stale && <p className="mt-1 text-sm font-semibold text-amber-100" role="status">{staleNotice}</p>}
+    {status.refreshError && <p className="mt-1 text-sm font-semibold text-amber-100" role="status">Unable to refresh status. Showing the last known update.</p>}
     <Link to="/status" className="mt-3 inline-flex text-sm font-semibold text-cyan-200 hover:text-cyan-100">View details →</Link>
   </div>;
 }

--- a/src/components/StatusSummary.jsx
+++ b/src/components/StatusSummary.jsx
@@ -60,7 +60,7 @@ export default function StatusSummary() {
     {supporting && <p className="mt-1 text-sm text-slate-300">{supporting}</p>}
     {freshness && <p className="mt-1 text-sm text-slate-400">{freshness}</p>}
     {status.stale && <p className="mt-1 text-sm font-semibold text-amber-100" role="status">{staleNotice}</p>}
-    {status.phase === 'ready' && status.refreshError && <p className="mt-1 text-sm font-semibold text-amber-100" role="status">Unable to refresh status. Showing the last known update.</p>}
+    {status.phase === 'ready' && !status.noSnapshot && status.refreshError && <p className="mt-1 text-sm font-semibold text-amber-100" role="status">Unable to refresh status. Showing the last known update.</p>}
     <Link to="/status" className="mt-3 inline-flex text-sm font-semibold text-cyan-200 hover:text-cyan-100">View details →</Link>
   </div>;
 }

--- a/src/components/StatusSummary.test.jsx
+++ b/src/components/StatusSummary.test.jsx
@@ -44,6 +44,32 @@ describe('StatusSummary', () => {
     expect(screen.getByText('Current service status is not available yet.')).toBeInTheDocument();
   });
 
+  it('does not claim a last known update after a no-snapshot response fails to refresh', async () => {
+    vi.useFakeTimers();
+    const fetch = vi.fn()
+      .mockResolvedValueOnce(response({
+        status: 'unknown', generated_at: null, snapshot_age_seconds: null, stale: true,
+        messages: ['Status snapshot is not yet available'], checks: {},
+      }))
+      .mockRejectedValueOnce(new Error('offline'));
+    vi.stubGlobal('fetch', fetch);
+    renderSummary();
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(screen.getByText('Status information unavailable')).toBeInTheDocument();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(60000);
+      await Promise.resolve();
+    });
+    expect(screen.getByText('A status snapshot is not available yet.')).toBeInTheDocument();
+    expect(screen.queryByText('Unable to refresh status. Showing the last known update.')).not.toBeInTheDocument();
+    expect(fetch).toHaveBeenCalledTimes(2);
+  });
+
   it('does not claim messaging and sign-in are operational without evidence for both', async () => {
     vi.stubGlobal('fetch', vi.fn().mockResolvedValue(response({ checks: { calls: 'degraded', matrix: 'mystery', login: 'ok' } })));
     renderSummary();

--- a/src/components/StatusSummary.test.jsx
+++ b/src/components/StatusSummary.test.jsx
@@ -26,6 +26,14 @@ describe('StatusSummary', () => {
     expect(screen.getByText('5 services are affected.')).toBeInTheDocument();
   });
 
+  it('does not claim retained data exists when the initial status request fails', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('offline')));
+    renderSummary();
+
+    expect(await screen.findByText('Status is temporarily unavailable')).toBeInTheDocument();
+    expect(screen.queryByText('Unable to refresh status. Showing the last known update.')).not.toBeInTheDocument();
+  });
+
   it('distinguishes a structured no-snapshot response from a feed failure', async () => {
     vi.stubGlobal('fetch', vi.fn().mockResolvedValue(response({
       status: 'unknown', generated_at: null, snapshot_age_seconds: null, stale: true,

--- a/src/components/StatusSummary.test.jsx
+++ b/src/components/StatusSummary.test.jsx
@@ -16,6 +16,26 @@ afterEach(() => {
 });
 
 describe('StatusSummary', () => {
+  it('reports the feed-level production outage even when the website is operational', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(response({
+      status: 'down', stale: false,
+      checks: { website: 'ok', login: 'degraded', matrix: 'down', media: 'down', calls: 'down', membership: 'down' },
+    })));
+    renderSummary();
+    expect(await screen.findByText('Service outage detected')).toBeInTheDocument();
+    expect(screen.getByText('5 services are affected.')).toBeInTheDocument();
+  });
+
+  it('distinguishes a structured no-snapshot response from a feed failure', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(response({
+      status: 'unknown', generated_at: null, snapshot_age_seconds: null, stale: true,
+      messages: ['Status snapshot is not yet available'], checks: {},
+    })));
+    renderSummary();
+    expect(await screen.findByText('Status information unavailable')).toBeInTheDocument();
+    expect(screen.getByText('Current service status is not available yet.')).toBeInTheDocument();
+  });
+
   it('does not claim messaging and sign-in are operational without evidence for both', async () => {
     vi.stubGlobal('fetch', vi.fn().mockResolvedValue(response({ checks: { calls: 'degraded', matrix: 'mystery', login: 'ok' } })));
     renderSummary();
@@ -56,7 +76,7 @@ describe('StatusSummary', () => {
     expect(await screen.findByText('Status information may be out of date')).toBeInTheDocument();
     expect(screen.queryByText('All systems operational')).not.toBeInTheDocument();
     expect(screen.getByText('Service status')).toBeInTheDocument();
-    expect(screen.getByRole('status')).toHaveTextContent('Status snapshot is stale. Showing the last known status; it may be out of date.');
+    expect(screen.getByRole('status')).toHaveTextContent('Showing the last reported service status.');
   });
 
   it('keeps freshness visible for an incident and warns when its refresh fails', async () => {
@@ -79,7 +99,7 @@ describe('StatusSummary', () => {
       await vi.advanceTimersByTimeAsync(60000);
       await Promise.resolve();
     });
-    expect(screen.getByRole('status')).toHaveTextContent('Status snapshot is stale. Showing the last known status; it may be out of date.');
+    expect(screen.getByRole('status')).toHaveTextContent('Unable to refresh status. Showing the last known update.');
     expect(fetch).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/pages/Status.jsx
+++ b/src/pages/Status.jsx
@@ -54,6 +54,7 @@ export default function Status() {
   const status = useLocalStatus({ refreshIntervalMs: 60000 });
   const error = status.phase === 'error';
   const snapshotMissing = status.phase === 'ready' && status.noSnapshot;
+  const affectedCount = status.components.filter(({ state }) => state === 'degraded' || state === 'unavailable').length;
   const hasUnknownComponent = status.components.some(({ state }) => state === 'unknown');
   const websiteOperational = status.components.some(({ id, state }) => id === 'website' && state === 'operational');
   const headline = snapshotMissing
@@ -66,7 +67,9 @@ export default function Status() {
     : status.stale
       ? `Showing the last reported service status. Last reported state: ${statusHeadline(status.overall)}.`
       : status.overall === 'unavailable' && websiteOperational
-        ? 'Several CK Conflux services are currently unavailable. The website remains available.'
+        ? affectedCount > 1
+          ? `${affectedCount} CK Conflux services are currently affected. The website remains available.`
+          : 'One or more CK Conflux services are currently unavailable. The website remains available.'
         : status.overall === 'unknown' && !hasUnknownComponent
         ? 'Status information is incomplete; the status feed did not confirm a complete platform state.'
         : DETAILS[status.overall];

--- a/src/pages/Status.jsx
+++ b/src/pages/Status.jsx
@@ -1,7 +1,5 @@
 import { ExternalLink } from '../components/SiteLink';
 import {
-  INDEPENDENT_STATUS_BADGE_LINK,
-  INDEPENDENT_STATUS_BADGE_URL,
   INDEPENDENT_STATUS_URL,
   stateLabel,
   statusHeadline,
@@ -55,25 +53,28 @@ function Freshness({ status }) {
 export default function Status() {
   const status = useLocalStatus({ refreshIntervalMs: 60000 });
   const error = status.phase === 'error';
-  const snapshotMissing = status.phase === 'ready' && status.stale && status.components.length === 0 && !status.generatedAt;
+  const snapshotMissing = status.phase === 'ready' && status.noSnapshot;
   const hasUnknownComponent = status.components.some(({ state }) => state === 'unknown');
+  const websiteOperational = status.components.some(({ id, state }) => id === 'website' && state === 'operational');
   const headline = snapshotMissing
-    ? 'Status snapshot unavailable'
+    ? 'Status information unavailable'
     : status.stale
       ? 'Status information may be out of date'
       : statusHeadline(status.overall);
   const detail = snapshotMissing
-    ? 'CK Conflux has not produced a status snapshot yet. Check independent monitoring below for an outside view.'
+    ? 'Current service status is not available yet.'
     : status.stale
-      ? `CK Conflux is serving its last completed status snapshot. Last reported state: ${statusHeadline(status.overall)}.`
-      : status.overall === 'unknown' && !hasUnknownComponent
+      ? `Showing the last reported service status. Last reported state: ${statusHeadline(status.overall)}.`
+      : status.overall === 'unavailable' && websiteOperational
+        ? 'Several CK Conflux services are currently unavailable. The website remains available.'
+        : status.overall === 'unknown' && !hasUnknownComponent
         ? 'Status information is incomplete; the status feed did not confirm a complete platform state.'
         : DETAILS[status.overall];
   const statusStyle = status.stale ? STATE_STYLE.degraded : STATE_STYLE[status.overall];
   const statusIcon = status.stale ? '!' : ICONS[status.overall];
   const staleNotice = snapshotMissing
-    ? 'Current platform health could not be confirmed.'
-    : 'Status snapshot is stale. Showing the last known status; it may be out of date.';
+    ? 'A status snapshot is not available yet.'
+    : 'Showing the last reported service status.';
 
   return <div className="mx-auto w-full max-w-5xl px-4 py-14 sm:px-6 lg:px-8 lg:py-20">
     <header className="max-w-3xl"><p className="text-sm font-semibold uppercase tracking-[0.18em] text-cyan-200">Availability</p><h1 className="mt-2 text-3xl font-semibold text-white sm:text-4xl">Service status</h1><p className="mt-4 leading-7 text-slate-300">Current user-facing health reported by CK Conflux.</p></header>
@@ -81,8 +82,8 @@ export default function Status() {
     <section className="mt-8" aria-labelledby="overall-status">
       <div className="flex flex-wrap items-center justify-between gap-3"><h2 id="overall-status" className="text-sm font-semibold uppercase tracking-[0.16em] text-slate-300">Overall CK Conflux status</h2><button type="button" onClick={status.refresh} disabled={status.isRefreshing} className="rounded-lg border border-white/20 px-4 py-2 text-sm font-semibold text-white hover:border-cyan-200 disabled:cursor-wait disabled:opacity-60">{status.isRefreshing ? 'Refreshing…' : 'Refresh'}</button></div>
       {status.phase === 'loading' && <div className="mt-4 min-h-32 rounded-2xl border border-white/10 bg-white/5 p-6 text-slate-300" role="status">Checking CK Conflux service health…</div>}
-      {error && <div className="mt-4 rounded-2xl border border-amber-300/40 bg-amber-400/10 p-6" role="alert"><div className="flex items-start gap-4"><span aria-hidden="true" className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full border border-amber-200 font-bold text-amber-100">!</span><div><h3 className="text-xl font-semibold text-white">We couldn't retrieve CK Conflux service health</h3><p className="mt-2 leading-7 text-slate-200">We couldn't retrieve the CK Conflux status feed. This does not necessarily mean the platform is down. Check independent monitoring below for an outside view.</p></div></div></div>}
-      {status.phase === 'ready' && <div className={`mt-4 rounded-2xl border p-6 ${statusStyle}`}><div className="flex items-start gap-4"><span aria-hidden="true" className="flex h-11 w-11 shrink-0 items-center justify-center rounded-full border border-current text-xl font-bold">{statusIcon}</span><div><h3 className="text-2xl font-semibold text-white" aria-live="polite" aria-atomic="true">{headline}</h3><p className="mt-2 leading-7 text-slate-200">{detail}</p><div className="mt-3"><Freshness status={status} /></div>{status.stale && <p className="mt-3 font-semibold text-amber-100" role="status">{staleNotice}</p>}{status.isRefreshing && <p className="mt-3 text-sm text-slate-300" role="status">Refreshing status…</p>}</div></div></div>}
+      {error && <div className="mt-4 rounded-2xl border border-amber-300/40 bg-amber-400/10 p-6" role="alert"><div className="flex items-start gap-4"><span aria-hidden="true" className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full border border-amber-200 font-bold text-amber-100">!</span><div><h3 className="text-xl font-semibold text-white">Status information unavailable</h3><p className="mt-2 leading-7 text-slate-200">We couldn't load the current service status.</p><button type="button" onClick={status.refresh} className="mt-4 rounded-lg border border-white/20 px-4 py-2 text-sm font-semibold text-white hover:border-cyan-200">Retry</button></div></div></div>}
+      {status.phase === 'ready' && <div className={`mt-4 rounded-2xl border p-6 ${statusStyle}`}><div className="flex items-start gap-4"><span aria-hidden="true" className="flex h-11 w-11 shrink-0 items-center justify-center rounded-full border border-current text-xl font-bold">{statusIcon}</span><div><h3 className="text-2xl font-semibold text-white" aria-live="polite" aria-atomic="true">{headline}</h3><p className="mt-2 leading-7 text-slate-200">{detail}</p><div className="mt-3"><Freshness status={status} /></div>{status.stale && <p className="mt-3 font-semibold text-amber-100" role="status">{staleNotice}</p>}{status.refreshError && <p className="mt-3 font-semibold text-amber-100" role="status">Unable to refresh status. Showing the last known update.</p>}{status.isRefreshing && <p className="mt-3 text-sm text-slate-300" role="status">Refreshing status…</p>}</div></div></div>}
     </section>
 
     {status.phase === 'ready' && status.components.length > 0 && <section className="mt-10" aria-labelledby="services-status"><h2 id="services-status" className="text-2xl font-semibold text-white">Services</h2><p className="mt-2 text-slate-300">Health is grouped by the CK Conflux features people use.</p><ul className="mt-5 grid gap-3 sm:grid-cols-2">{status.components.map((component) => {
@@ -90,6 +91,6 @@ export default function Status() {
       return <li key={component.id} className={`rounded-xl border p-4 ${affected ? STATE_STYLE[component.state] : 'border-white/10 bg-white/5'}`}><div className="flex items-center justify-between gap-4"><span className="font-medium text-white">{component.name}</span><strong className="flex items-center gap-2 text-sm text-white"><span aria-hidden="true">{ICONS[component.state]}</span>{stateLabel(component.state)}</strong></div>{affected && <p className="mt-3 text-sm leading-6 text-slate-200">{IMPACT[component.id] || 'This service may not work normally.'}</p>}</li>;
     })}</ul></section>}
 
-    <section className={`mt-10 rounded-2xl border p-6 ${error || status.stale ? 'border-cyan-300/40 bg-cyan-400/10' : 'border-white/10 bg-white/5'}`} aria-labelledby="independent-status"><h2 id="independent-status" className="text-2xl font-semibold text-white">Independent monitoring</h2><p className="mt-3 max-w-3xl leading-7 text-slate-300">CK Conflux service health above is generated from platform and application checks. UptimeRobot independently monitors public CK Conflux endpoints from outside the platform.</p><p className="mt-2 max-w-3xl leading-7 text-slate-300">Use the independent page if CK Conflux itself is unreachable or if you want the outside-in view.</p><ExternalLink href={INDEPENDENT_STATUS_BADGE_LINK} target="_blank" rel="noopener noreferrer" className="mt-5 inline-flex" aria-label="View CK Conflux status on independent monitoring (opens in a new tab)"><img src={INDEPENDENT_STATUS_BADGE_URL} alt="CK Conflux independent monitoring status" className="h-7 max-w-full" /></ExternalLink><div><ExternalLink href={INDEPENDENT_STATUS_URL} target="_blank" rel="noopener noreferrer" className="mt-5 inline-flex rounded-xl bg-cyan-400 px-5 py-3 font-semibold text-slate-950">Open independent status page <span className="sr-only">(opens in a new tab)</span></ExternalLink></div></section>
+    <div className="mt-10 border-t border-white/10 pt-6"><ExternalLink href={INDEPENDENT_STATUS_URL} target="_blank" rel="noopener noreferrer" className="inline-flex text-sm font-semibold text-cyan-200 hover:text-cyan-100">View uptime history ↗ <span className="sr-only">(opens in a new tab)</span></ExternalLink></div>
   </div>;
 }

--- a/src/pages/Status.test.jsx
+++ b/src/pages/Status.test.jsx
@@ -10,6 +10,28 @@ afterEach(() => {
 });
 
 describe('Status page', () => {
+  it('renders a production-style HTTP 503 outage while preserving all six component states', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(response({
+      status: 'down',
+      generated_at: '2026-08-30T23:27:03Z',
+      messages: ['Synapse degraded', 'Media uploads degraded', 'Calls degraded', 'Membership services degraded'],
+      checks: { website: 'ok', login: 'degraded', matrix: 'down', media: 'down', calls: 'down', membership: 'down' },
+      snapshot_age_seconds: 7.2,
+      stale: false,
+    }, false, 503)));
+    render(<Status />);
+
+    expect(await screen.findByRole('heading', { name: 'Service outage detected' })).toBeInTheDocument();
+    expect(screen.getByText(/website remains available/i)).toBeInTheDocument();
+    expect(screen.getByText('Website').closest('li')).toHaveTextContent('Operational');
+    expect(screen.getByText('Sign in').closest('li')).toHaveTextContent('Degraded');
+    for (const name of ['Messaging', 'Voice & video', 'Media & uploads', 'Account & membership']) {
+      expect(screen.getByText(name).closest('li')).toHaveTextContent('Unavailable');
+    }
+    expect(screen.queryByRole('heading', { name: 'Status information unavailable' })).not.toBeInTheDocument();
+    expect(screen.queryByText('Synapse degraded')).not.toBeInTheDocument();
+  });
+
   it('does not claim absent services are healthy for a partial operational feed', async () => {
     vi.stubGlobal('fetch', vi.fn().mockResolvedValue(response({ checks: { matrix: 'ok', login: 'ok' } })));
     render(<Status />);
@@ -45,7 +67,7 @@ describe('Status page', () => {
 
     expect(await screen.findByRole('heading', { name: 'Status information may be out of date' })).toBeInTheDocument();
     expect(screen.queryByRole('heading', { name: 'All systems operational' })).not.toBeInTheDocument();
-    expect(screen.getByRole('status')).toHaveTextContent('Status snapshot is stale. Showing the last known status; it may be out of date.');
+    expect(screen.getByRole('status')).toHaveTextContent('Showing the last reported service status.');
     expect(screen.getByRole('heading', { name: 'Services' })).toBeInTheDocument();
   });
 
@@ -61,11 +83,10 @@ describe('Status page', () => {
 
     render(<Status />);
 
-    expect(await screen.findByRole('heading', { name: 'Status snapshot unavailable' })).toBeInTheDocument();
-    expect(screen.getByText(/has not produced a status snapshot yet/i)).toBeInTheDocument();
+    expect(await screen.findByRole('heading', { name: 'Status information unavailable' })).toBeInTheDocument();
+    expect(screen.getByText('Current service status is not available yet.')).toBeInTheDocument();
     expect(screen.queryByRole('heading', { name: 'Services' })).not.toBeInTheDocument();
-    expect(screen.queryByRole('heading', { name: "We couldn't retrieve CK Conflux service health" })).not.toBeInTheDocument();
-    expect(screen.getByRole('status')).toHaveTextContent('Current platform health could not be confirmed.');
+    expect(screen.getByText('A status snapshot is not available yet.')).toBeInTheDocument();
   });
 
   it('uses neutral incomplete wording when only the feed-level state is unknown', async () => {

--- a/src/pages/Status.test.jsx
+++ b/src/pages/Status.test.jsx
@@ -23,6 +23,7 @@ describe('Status page', () => {
 
     expect(await screen.findByRole('heading', { name: 'Service outage detected' })).toBeInTheDocument();
     expect(screen.getByText(/website remains available/i)).toBeInTheDocument();
+    expect(screen.getByText('5 CK Conflux services are currently affected. The website remains available.')).toBeInTheDocument();
     expect(screen.getByText('Website').closest('li')).toHaveTextContent('Operational');
     expect(screen.getByText('Sign in').closest('li')).toHaveTextContent('Degraded');
     for (const name of ['Messaging', 'Voice & video', 'Media & uploads', 'Account & membership']) {
@@ -30,6 +31,18 @@ describe('Status page', () => {
     }
     expect(screen.queryByRole('heading', { name: 'Status information unavailable' })).not.toBeInTheDocument();
     expect(screen.queryByText('Synapse degraded')).not.toBeInTheDocument();
+  });
+
+  it('does not overstate the outage breadth when only one component is affected', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(response({
+      status: 'down',
+      checks: { website: 'ok', calls: 'down' },
+    }, false, 503)));
+    render(<Status />);
+
+    expect(await screen.findByRole('heading', { name: 'Service outage detected' })).toBeInTheDocument();
+    expect(screen.getByText('One or more CK Conflux services are currently unavailable. The website remains available.')).toBeInTheDocument();
+    expect(screen.queryByText(/Several CK Conflux services/i)).not.toBeInTheDocument();
   });
 
   it('does not claim absent services are healthy for a partial operational feed', async () => {

--- a/src/status/status.js
+++ b/src/status/status.js
@@ -19,8 +19,6 @@ const LEGACY_METADATA_KEYS = new Set([
 
 export const STATUS_ENDPOINT = '/status.json';
 export const INDEPENDENT_STATUS_URL = 'https://status.ckconflux.com';
-export const INDEPENDENT_STATUS_BADGE_URL = 'https://badge.uptimerobot.com/psp/177dfd29052bc6cc25407cf35076378b.svg?style=text&theme=dark';
-export const INDEPENDENT_STATUS_BADGE_LINK = `${INDEPENDENT_STATUS_URL}?utm_source=status_badge&utm_medium=referral`;
 
 export function healthState(value) {
   const raw = typeof value === 'object' && value ? value.status ?? value.state ?? value.health ?? value.operational : value;
@@ -130,6 +128,7 @@ export function parseStatus(payload) {
     snapshotAgeSeconds,
     stale: payload.stale === true,
     messages,
+    noSnapshot,
   };
 }
 

--- a/src/status/useLocalStatus.js
+++ b/src/status/useLocalStatus.js
@@ -12,6 +12,7 @@ const EMPTY_RESULT = {
   isRefreshing: false,
   stale: false,
   refreshError: false,
+  noSnapshot: false,
 };
 
 export function useLocalStatus({ refreshIntervalMs = 0, timeoutMs = 8000 } = {}) {
@@ -41,7 +42,7 @@ export function useLocalStatus({ refreshIntervalMs = 0, timeoutMs = 8000 } = {})
     } catch {
       if (mounted.current && activeController.current === controller) {
         setResult((current) => current.phase === 'ready'
-          ? { ...current, isRefreshing: false, stale: true, refreshError: true }
+          ? { ...current, isRefreshing: false, refreshError: true }
           : { ...EMPTY_RESULT, phase: 'error', refreshError: true });
       }
     } finally {

--- a/src/status/useLocalStatus.test.jsx
+++ b/src/status/useLocalStatus.test.jsx
@@ -81,7 +81,7 @@ describe('useLocalStatus', () => {
     expect(result.current.phase).toBe('error');
   });
 
-  it('keeps successful data visible during refresh and marks it stale after failure', async () => {
+  it('keeps successful data visible and distinguishes a client refresh failure', async () => {
     let rejectRefresh;
     const fetch = vi.fn()
       .mockResolvedValueOnce(response(payload()))
@@ -95,9 +95,24 @@ describe('useLocalStatus', () => {
     expect(result.current.components[0].name).toBe('Messaging');
     await act(async () => { rejectRefresh(new Error('offline')); });
     expect(result.current.phase).toBe('ready');
-    expect(result.current.stale).toBe(true);
+    expect(result.current.stale).toBe(false);
     expect(result.current.refreshError).toBe(true);
     expect(fetch).toHaveBeenCalledTimes(2);
+  });
+
+  it('clears a refresh error after a later successful refresh', async () => {
+    const fetch = vi.fn()
+      .mockResolvedValueOnce(response(payload()))
+      .mockRejectedValueOnce(new Error('offline'))
+      .mockResolvedValueOnce(response(payload('degraded')));
+    vi.stubGlobal('fetch', fetch);
+    const { result } = renderHook(() => useLocalStatus());
+    await waitFor(() => expect(result.current.phase).toBe('ready'));
+    await act(async () => { await result.current.refresh(); });
+    expect(result.current.refreshError).toBe(true);
+    await act(async () => { await result.current.refresh(); });
+    expect(result.current.refreshError).toBe(false);
+    expect(result.current.overall).toBe('degraded');
   });
 
   it('manual refresh performs another successful request', async () => {


### PR DESCRIPTION
### Motivation
- Clarify and harden the service-status UX to match the authoritative `/status.json` contract, correctly represent fresh/degraded/down/stale/no-snapshot cases, and separate server-provided staleness from client refresh errors.
- Remove the large, confusing independent-monitoring section and redundant UptimeRobot badge so the primary experience focuses on the six public CK Conflux service states.
- Keep legacy payload compatibility while making the UI and tests explicitly exercise production outage/staleness/startup and client-refresh semantics.

### Description
- Parsing and state model: `src/status/status.js` recognizes the structured startup/no-snapshot contract and returns an explicit `noSnapshot` flag in `parseStatus`, preserving `stale`, `generated_at`, `snapshot_age_seconds`, `messages`, and all component entries.
- Client refresh behavior: `src/status/useLocalStatus.js` adds `noSnapshot` to the EMPTY_RESULT, preserves last-known data on client refresh failures, sets a `refreshError` flag without overwriting server-provided `stale`, and clears the flag after a successful refresh.
- Status page UX: `src/pages/Status.jsx` replaces the verbose independent-monitoring section with a compact external link (`View uptime history ↗`), improves headline/detail text for fresh healthy, degraded, outage, stale snapshots, structured no-snapshot startup, transport/parse errors, and client refresh failures; adds a keyboard-operable `Retry` action for true fetch/parse errors and a concise retained-data notice when refresh fails. Outage detail derives the affected-component count so the copy does not overstate a single-component or feed-level outage.
- Homepage summary: `src/components/StatusSummary.jsx` follows the same semantics and display rules: no stale healthy snapshot is called live, a full current-contract snapshot shows all six components, retained-data refresh warnings only appear when retained ready-state data actually exists, and a no-snapshot startup state continues to say no snapshot is available if a later refresh fails.
- Footer and external affordance: removed the global UptimeRobot badge from `src/components/Footer.jsx` to avoid duplicate/competing external monitoring affordances.
- Tests and coverage: regression coverage includes the production-style outage payload, stale snapshots, startup/no-snapshot contract, client refresh failure and recovery, initial fetch failure, no-snapshot followed by refresh failure, affected-component outage wording, HTTP 503 parsing, and homepage summary behavior.
- Files changed: `src/status/status.js`, `src/status/useLocalStatus.js`, `src/pages/Status.jsx`, `src/components/StatusSummary.jsx`, `src/components/Footer.jsx`, `src/status/useLocalStatus.test.jsx`, `src/pages/Status.test.jsx`, `src/components/StatusSummary.test.jsx`, `src/App.test.jsx`.

### Testing
Latest CI on head `79fa064` is green:
- `test-build`: 6 test files, 113 tests passed; production build and prerender succeeded; ESLint succeeded.
- `helm-validate`: succeeded.
- `docker`: PR image build and nginx canonical-route validation succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a94cc3f4f00832cb85aa70922cb506a)