### PR TITLE
Add subtle animated network globe background

### DIFF
--- a/src/components/NetworkGlobeBackground.jsx
+++ b/src/components/NetworkGlobeBackground.jsx
@@ -1,0 +1,73 @@
+const ROUTES = [
+  {
+    d: 'M 84 518 C 258 316 444 294 610 382 S 908 552 1122 302',
+    duration: '13s',
+    delay: '-2s',
+    secondary: false,
+  },
+  {
+    d: 'M 236 154 C 454 170 568 332 754 408 S 1012 488 1152 620',
+    duration: '16s',
+    delay: '-8s',
+    secondary: true,
+  },
+  {
+    d: 'M 444 674 C 590 548 650 446 728 348 S 900 202 1068 244',
+    duration: '14.5s',
+    delay: '-5s',
+    secondary: true,
+  },
+  {
+    d: 'M 610 392 C 708 222 864 184 1018 278',
+    duration: '10.5s',
+    delay: '-4s',
+    secondary: false,
+  },
+];
+
+const NODES = [
+  [178, 442],
+  [476, 322],
+  [610, 382],
+  [724, 348],
+  [820, 214],
+  [926, 438],
+  [1018, 278],
+  [1090, 326],
+];
+
+export default function NetworkGlobeBackground() {
+  return <div className="network-globe-background" aria-hidden="true">
+    <div className="network-globe__aurora" />
+    <svg className="network-globe__svg" viewBox="0 0 1200 800" fill="none" focusable="false" preserveAspectRatio="xMidYMid meet">
+      <g className="network-globe__sphere">
+        <circle cx="820" cy="360" r="250" />
+        <ellipse cx="820" cy="360" rx="250" ry="86" />
+        <ellipse cx="820" cy="360" rx="250" ry="164" />
+        <ellipse cx="820" cy="360" rx="86" ry="250" />
+        <ellipse cx="820" cy="360" rx="164" ry="250" />
+        <ellipse cx="820" cy="360" rx="108" ry="250" transform="rotate(34 820 360)" />
+        <ellipse cx="820" cy="360" rx="108" ry="250" transform="rotate(-34 820 360)" />
+      </g>
+
+      <g className="network-globe__routes">
+        {ROUTES.map((route, index) => <g key={route.d} className={route.secondary ? 'network-globe__route--secondary' : undefined}>
+          <path d={route.d} className="network-globe__route" />
+          <path
+            d={route.d}
+            pathLength="100"
+            className="network-globe__flow"
+            style={{ '--network-flow-duration': route.duration, '--network-flow-delay': route.delay }}
+          />
+        </g>)}
+      </g>
+
+      <g className="network-globe__nodes">
+        {NODES.map(([cx, cy]) => <g key={`${cx}-${cy}`} transform={`translate(${cx} ${cy})`}>
+          <circle r="8" className="network-globe__node-ring" />
+          <circle r="2.25" className="network-globe__node" />
+        </g>)}
+      </g>
+    </svg>
+  </div>;
+}

--- a/src/components/NetworkGlobeBackground.jsx
+++ b/src/components/NetworkGlobeBackground.jsx
@@ -51,7 +51,7 @@ export default function NetworkGlobeBackground() {
       </g>
 
       <g className="network-globe__routes">
-        {ROUTES.map((route, index) => <g key={route.d} className={route.secondary ? 'network-globe__route--secondary' : undefined}>
+        {ROUTES.map((route) => <g key={route.d} className={route.secondary ? 'network-globe__route--secondary' : undefined}>
           <path d={route.d} className="network-globe__route" />
           <path
             d={route.d}

--- a/src/components/NetworkGlobeBackground.jsx
+++ b/src/components/NetworkGlobeBackground.jsx
@@ -1,39 +1,28 @@
-const ROUTES = [
-  {
-    d: 'M 84 518 C 258 316 444 294 610 382 S 908 552 1122 302',
-    duration: '13s',
-    delay: '-2s',
-    secondary: false,
-  },
-  {
-    d: 'M 236 154 C 454 170 568 332 754 408 S 1012 488 1152 620',
-    duration: '16s',
-    delay: '-8s',
-    secondary: true,
-  },
-  {
-    d: 'M 444 674 C 590 548 650 446 728 348 S 900 202 1068 244',
-    duration: '14.5s',
-    delay: '-5s',
-    secondary: true,
-  },
-  {
-    d: 'M 610 392 C 708 222 864 184 1018 278',
-    duration: '10.5s',
-    delay: '-4s',
-    secondary: false,
-  },
+const HOMESERVERS = [
+  { id: 'hs-a', x: 382, y: 246, secondary: false, users: [[318, 198], [312, 284], [416, 184]] },
+  { id: 'hs-b', x: 590, y: 168, secondary: false, users: [[538, 112], [614, 102], [654, 150]] },
+  { id: 'hs-c', x: 806, y: 226, secondary: false, users: [[790, 152], [866, 176], [874, 246]] },
+  { id: 'hs-d', x: 1010, y: 350, secondary: false, users: [[1046, 288], [1082, 354], [1048, 414]] },
+  { id: 'hs-e', x: 892, y: 548, secondary: false, users: [[954, 516], [952, 586], [866, 620]] },
+  { id: 'hs-f', x: 650, y: 602, secondary: false, users: [[604, 664], [680, 674], [716, 620]] },
+  { id: 'hs-g', x: 440, y: 514, secondary: true, users: [[366, 510], [390, 574], [470, 588]] },
+  { id: 'hs-h', x: 684, y: 382, secondary: true, users: [[622, 342], [708, 314], [742, 410]] },
 ];
 
-const NODES = [
-  [178, 442],
-  [476, 322],
-  [610, 382],
-  [724, 348],
-  [820, 214],
-  [926, 438],
-  [1018, 278],
-  [1090, 326],
+const FEDERATION_LINKS = [
+  { d: 'M 382 246 Q 478 176 590 168', duration: '12s', delay: '-2s', reverse: false, secondary: false },
+  { d: 'M 590 168 Q 700 154 806 226', duration: '15s', delay: '-7s', reverse: true, secondary: false },
+  { d: 'M 806 226 Q 930 244 1010 350', duration: '13s', delay: '-5s', reverse: false, secondary: false },
+  { d: 'M 1010 350 Q 1028 470 892 548', duration: '16s', delay: '-9s', reverse: true, secondary: false },
+  { d: 'M 892 548 Q 774 624 650 602', duration: '14s', delay: '-4s', reverse: false, secondary: false },
+  { d: 'M 650 602 Q 530 624 440 514', duration: '17s', delay: '-11s', reverse: true, secondary: true },
+  { d: 'M 440 514 Q 328 394 382 246', duration: '15s', delay: '-6s', reverse: false, secondary: true },
+  { d: 'M 382 246 Q 566 238 806 226', duration: '18s', delay: '-13s', reverse: true, secondary: false },
+  { d: 'M 590 168 Q 646 280 684 382', duration: '11s', delay: '-3s', reverse: false, secondary: true },
+  { d: 'M 806 226 Q 744 312 684 382', duration: '12.5s', delay: '-8s', reverse: true, secondary: true },
+  { d: 'M 1010 350 Q 840 394 684 382', duration: '17s', delay: '-10s', reverse: false, secondary: true },
+  { d: 'M 892 548 Q 790 432 684 382', duration: '14.5s', delay: '-1s', reverse: true, secondary: true },
+  { d: 'M 440 514 Q 564 438 684 382', duration: '16.5s', delay: '-12s', reverse: false, secondary: true },
 ];
 
 export default function NetworkGlobeBackground() {
@@ -41,31 +30,61 @@ export default function NetworkGlobeBackground() {
     <div className="network-globe__aurora" />
     <svg className="network-globe__svg" viewBox="0 0 1200 800" fill="none" focusable="false" preserveAspectRatio="xMidYMid meet">
       <g className="network-globe__sphere">
-        <circle cx="820" cy="360" r="250" />
-        <ellipse cx="820" cy="360" rx="250" ry="86" />
-        <ellipse cx="820" cy="360" rx="250" ry="164" />
-        <ellipse cx="820" cy="360" rx="86" ry="250" />
-        <ellipse cx="820" cy="360" rx="164" ry="250" />
-        <ellipse cx="820" cy="360" rx="108" ry="250" transform="rotate(34 820 360)" />
-        <ellipse cx="820" cy="360" rx="108" ry="250" transform="rotate(-34 820 360)" />
+        <circle cx="700" cy="390" r="326" />
+        <ellipse cx="700" cy="390" rx="326" ry="112" />
+        <ellipse cx="700" cy="390" rx="326" ry="220" />
+        <ellipse cx="700" cy="390" rx="118" ry="326" />
+        <ellipse cx="700" cy="390" rx="228" ry="326" />
+        <ellipse cx="700" cy="390" rx="144" ry="326" transform="rotate(35 700 390)" />
+        <ellipse cx="700" cy="390" rx="144" ry="326" transform="rotate(-35 700 390)" />
       </g>
 
-      <g className="network-globe__routes">
-        {ROUTES.map((route) => <g key={route.d} className={route.secondary ? 'network-globe__route--secondary' : undefined}>
-          <path d={route.d} className="network-globe__route" />
+      <g className="network-globe__federation">
+        {FEDERATION_LINKS.map((link) => <g key={link.d} className={link.secondary ? 'network-globe__federation--secondary' : undefined}>
+          <path d={link.d} className="network-globe__route" />
           <path
-            d={route.d}
+            d={link.d}
             pathLength="100"
-            className="network-globe__flow"
-            style={{ '--network-flow-duration': route.duration, '--network-flow-delay': route.delay }}
+            className={`network-globe__flow ${link.reverse ? 'network-globe__flow--reverse' : ''}`}
+            style={{ '--network-flow-duration': link.duration, '--network-flow-delay': link.delay }}
           />
         </g>)}
       </g>
 
-      <g className="network-globe__nodes">
-        {NODES.map(([cx, cy]) => <g key={`${cx}-${cy}`} transform={`translate(${cx} ${cy})`}>
-          <circle r="8" className="network-globe__node-ring" />
-          <circle r="2.25" className="network-globe__node" />
+      <g className="network-globe__servers">
+        {HOMESERVERS.map((server, serverIndex) => <g
+          key={server.id}
+          className={`network-globe__server ${server.secondary ? 'network-globe__server--secondary' : ''}`}
+        >
+          <g className="network-globe__client-links">
+            {server.users.map(([userX, userY], userIndex) => <g key={`${server.id}-user-${userIndex}`}>
+              <line x1={server.x} y1={server.y} x2={userX} y2={userY} className="network-globe__client-link" />
+              {userIndex === 0 && <line
+                x1={server.x}
+                y1={server.y}
+                x2={userX}
+                y2={userY}
+                pathLength="100"
+                className={`network-globe__client-flow ${(serverIndex + userIndex) % 2 ? 'network-globe__flow--reverse' : ''}`}
+                style={{
+                  '--network-flow-duration': `${9 + serverIndex * 0.8}s`,
+                  '--network-flow-delay': `${-1.5 * serverIndex}s`,
+                }}
+              />}
+            </g>)}
+          </g>
+
+          <g transform={`translate(${server.x} ${server.y})`} className="network-globe__homeserver">
+            <circle r="12" className="network-globe__homeserver-ring" />
+            <circle r="4" className="network-globe__homeserver-core" />
+          </g>
+
+          <g className="network-globe__users">
+            {server.users.map(([userX, userY], userIndex) => <g key={`${server.id}-node-${userIndex}`} transform={`translate(${userX} ${userY})`}>
+              <circle r="4.25" className="network-globe__user-ring" />
+              <circle r="1.7" className="network-globe__user-node" />
+            </g>)}
+          </g>
         </g>)}
       </g>
     </svg>

--- a/src/components/NetworkGlobeBackground.test.jsx
+++ b/src/components/NetworkGlobeBackground.test.jsx
@@ -3,13 +3,19 @@ import { describe, expect, it } from 'vitest';
 import NetworkGlobeBackground from './NetworkGlobeBackground';
 
 describe('NetworkGlobeBackground', () => {
-  it('renders as decorative content with lightweight SVG flow routes', () => {
+  it('renders a decorative federated network with homeservers, users, and normalized traffic paths', () => {
     const { container } = render(<NetworkGlobeBackground />);
     const background = container.querySelector('.network-globe-background');
+    const federationFlows = container.querySelectorAll('.network-globe__flow');
+    const clientFlows = container.querySelectorAll('.network-globe__client-flow');
 
     expect(background).toHaveAttribute('aria-hidden', 'true');
     expect(container.querySelector('svg')).toHaveAttribute('focusable', 'false');
-    expect(container.querySelectorAll('.network-globe__flow')).toHaveLength(4);
-    expect(container.querySelectorAll('.network-globe__node')).toHaveLength(8);
+    expect(container.querySelectorAll('.network-globe__homeserver-core')).toHaveLength(8);
+    expect(container.querySelectorAll('.network-globe__user-node')).toHaveLength(24);
+    expect(federationFlows).toHaveLength(13);
+    expect(clientFlows).toHaveLength(8);
+    expect(container.querySelectorAll('.network-globe__flow--reverse').length).toBeGreaterThan(0);
+    [...federationFlows, ...clientFlows].forEach((flow) => expect(flow).toHaveAttribute('pathLength', '100'));
   });
 });

--- a/src/components/NetworkGlobeBackground.test.jsx
+++ b/src/components/NetworkGlobeBackground.test.jsx
@@ -1,0 +1,15 @@
+import { render } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import NetworkGlobeBackground from './NetworkGlobeBackground';
+
+describe('NetworkGlobeBackground', () => {
+  it('renders as decorative content with lightweight SVG flow routes', () => {
+    const { container } = render(<NetworkGlobeBackground />);
+    const background = container.querySelector('.network-globe-background');
+
+    expect(background).toHaveAttribute('aria-hidden', 'true');
+    expect(container.querySelector('svg')).toHaveAttribute('focusable', 'false');
+    expect(container.querySelectorAll('.network-globe__flow')).toHaveLength(4);
+    expect(container.querySelectorAll('.network-globe__node')).toHaveLength(8);
+  });
+});

--- a/src/index.css
+++ b/src/index.css
@@ -31,6 +31,116 @@ header.sticky > div > a[href="/"]:first-child::before {
   background: url('/brand/v1/ckconflux-symbol.svg') center / contain no-repeat;
 }
 
+.network-globe-background {
+  position: fixed;
+  inset: 0;
+  z-index: 0;
+  overflow: hidden;
+  pointer-events: none;
+  contain: paint;
+}
+
+.network-globe__aurora {
+  position: absolute;
+  inset: -12% -8% auto auto;
+  width: min(74rem, 112vw);
+  aspect-ratio: 1;
+  border-radius: 9999px;
+  background:
+    radial-gradient(circle at 58% 42%, rgba(34, 211, 238, 0.09), transparent 34%),
+    radial-gradient(circle at 48% 52%, rgba(59, 130, 246, 0.045), transparent 52%);
+}
+
+.network-globe__svg {
+  position: absolute;
+  top: clamp(2.5rem, 7vh, 6rem);
+  right: max(-18rem, -17vw);
+  width: min(82rem, 116vw);
+  height: auto;
+  opacity: 0.58;
+}
+
+.network-globe__sphere > * {
+  vector-effect: non-scaling-stroke;
+  stroke: rgba(103, 232, 249, 0.13);
+  stroke-width: 0.9;
+}
+
+.network-globe__route,
+.network-globe__flow {
+  vector-effect: non-scaling-stroke;
+  fill: none;
+  stroke-linecap: round;
+}
+
+.network-globe__route {
+  stroke: rgba(103, 232, 249, 0.11);
+  stroke-width: 1;
+}
+
+.network-globe__flow {
+  stroke: rgba(103, 232, 249, 0.5);
+  stroke-width: 1.25;
+  stroke-dasharray: 1.15 9.5;
+  stroke-dashoffset: 0;
+  opacity: 0.7;
+  animation: network-globe-flow var(--network-flow-duration, 14s) linear infinite;
+  animation-delay: var(--network-flow-delay, 0s);
+}
+
+.network-globe__node-ring,
+.network-globe__node {
+  vector-effect: non-scaling-stroke;
+}
+
+.network-globe__node-ring {
+  fill: rgba(34, 211, 238, 0.025);
+  stroke: rgba(103, 232, 249, 0.16);
+  stroke-width: 0.8;
+}
+
+.network-globe__node {
+  fill: rgba(165, 243, 252, 0.72);
+}
+
+@keyframes network-globe-flow {
+  to {
+    stroke-dashoffset: -100;
+  }
+}
+
+@media (max-width: 767px) {
+  .network-globe__aurora {
+    top: 2rem;
+    right: 50%;
+    width: 54rem;
+    transform: translateX(50%);
+    opacity: 0.82;
+  }
+
+  .network-globe__svg {
+    top: 5rem;
+    right: auto;
+    left: 50%;
+    width: 50rem;
+    max-width: none;
+    transform: translateX(-50%);
+    opacity: 0.42;
+  }
+
+  .network-globe__route--secondary {
+    display: none;
+  }
+
+  .network-globe__sphere > * {
+    stroke: rgba(103, 232, 249, 0.105);
+  }
+
+  .network-globe__flow {
+    opacity: 0.5;
+  }
+}
+
 :focus-visible {
   outline: 2px solid #67e8f9;
   outline-offset: 3px;
@@ -42,5 +152,10 @@ header.sticky > div > a[href="/"]:first-child::before {
     animation-duration: 0.01ms !important;
     animation-iteration-count: 1 !important;
     transition-duration: 0.01ms !important;
+  }
+
+  .network-globe__flow {
+    animation: none !important;
+    opacity: 0.22;
   }
 }

--- a/src/index.css
+++ b/src/index.css
@@ -42,70 +42,124 @@ header.sticky > div > a[href="/"]:first-child::before {
 
 .network-globe__aurora {
   position: absolute;
-  inset: -12% -8% auto auto;
-  width: min(74rem, 112vw);
+  inset: -14% -10% auto auto;
+  width: min(76rem, 114vw);
   aspect-ratio: 1;
   border-radius: 9999px;
   background:
-    radial-gradient(circle at 58% 42%, rgba(34, 211, 238, 0.09), transparent 34%),
-    radial-gradient(circle at 48% 52%, rgba(59, 130, 246, 0.045), transparent 52%);
+    radial-gradient(circle at 55% 44%, rgba(34, 211, 238, 0.08), transparent 34%),
+    radial-gradient(circle at 48% 52%, rgba(59, 130, 246, 0.04), transparent 54%);
 }
 
 .network-globe__svg {
   position: absolute;
   top: clamp(2.5rem, 7vh, 6rem);
-  right: max(-18rem, -17vw);
-  width: min(82rem, 116vw);
+  right: max(-14rem, -13vw);
+  width: min(84rem, 118vw);
   height: auto;
-  opacity: 0.58;
+  opacity: 0.56;
 }
 
 .network-globe__sphere > * {
   vector-effect: non-scaling-stroke;
-  stroke: rgba(103, 232, 249, 0.13);
-  stroke-width: 0.9;
+  stroke: rgba(103, 232, 249, 0.09);
+  stroke-width: 0.8;
 }
 
 .network-globe__route,
-.network-globe__flow {
+.network-globe__flow,
+.network-globe__client-link,
+.network-globe__client-flow {
   vector-effect: non-scaling-stroke;
   fill: none;
   stroke-linecap: round;
 }
 
 .network-globe__route {
-  stroke: rgba(103, 232, 249, 0.11);
-  stroke-width: 1;
+  stroke: rgba(103, 232, 249, 0.105);
+  stroke-width: 0.9;
 }
 
-.network-globe__flow {
-  stroke: rgba(103, 232, 249, 0.5);
-  stroke-width: 1.25;
-  stroke-dasharray: 1.15 9.5;
+.network-globe__client-link {
+  stroke: rgba(103, 232, 249, 0.075);
+  stroke-width: 0.75;
+}
+
+/*
+ * Every moving dash pattern has a 10-unit period and travels exactly 100 units.
+ * The first and last frames are therefore phase-identical, so the infinite loop
+ * has no visual reset or jump.
+ */
+.network-globe__flow,
+.network-globe__client-flow {
   stroke-dashoffset: 0;
-  opacity: 0.7;
-  animation: network-globe-flow var(--network-flow-duration, 14s) linear infinite;
+  animation-name: network-globe-flow-forward;
+  animation-duration: var(--network-flow-duration, 14s);
+  animation-timing-function: linear;
+  animation-iteration-count: infinite;
   animation-delay: var(--network-flow-delay, 0s);
 }
 
-.network-globe__node-ring,
-.network-globe__node {
+.network-globe__flow {
+  stroke: rgba(103, 232, 249, 0.48);
+  stroke-width: 1.2;
+  stroke-dasharray: 1.5 8.5;
+  opacity: 0.62;
+}
+
+.network-globe__client-flow {
+  stroke: rgba(165, 243, 252, 0.34);
+  stroke-width: 0.9;
+  stroke-dasharray: 0.8 9.2;
+  opacity: 0.58;
+}
+
+.network-globe__flow--reverse {
+  animation-name: network-globe-flow-reverse;
+}
+
+.network-globe__homeserver-ring,
+.network-globe__homeserver-core,
+.network-globe__user-ring,
+.network-globe__user-node {
   vector-effect: non-scaling-stroke;
 }
 
-.network-globe__node-ring {
+.network-globe__homeserver-ring {
   fill: rgba(34, 211, 238, 0.025);
-  stroke: rgba(103, 232, 249, 0.16);
-  stroke-width: 0.8;
+  stroke: rgba(103, 232, 249, 0.22);
+  stroke-width: 0.9;
 }
 
-.network-globe__node {
-  fill: rgba(165, 243, 252, 0.72);
+.network-globe__homeserver-core {
+  fill: rgba(165, 243, 252, 0.68);
 }
 
-@keyframes network-globe-flow {
+.network-globe__user-ring {
+  fill: rgba(34, 211, 238, 0.018);
+  stroke: rgba(103, 232, 249, 0.12);
+  stroke-width: 0.65;
+}
+
+.network-globe__user-node {
+  fill: rgba(186, 230, 253, 0.56);
+}
+
+@keyframes network-globe-flow-forward {
+  from {
+    stroke-dashoffset: 0;
+  }
   to {
     stroke-dashoffset: -100;
+  }
+}
+
+@keyframes network-globe-flow-reverse {
+  from {
+    stroke-dashoffset: 0;
+  }
+  to {
+    stroke-dashoffset: 100;
   }
 }
 
@@ -113,31 +167,36 @@ header.sticky > div > a[href="/"]:first-child::before {
   .network-globe__aurora {
     top: 2rem;
     right: 50%;
-    width: 54rem;
+    width: 56rem;
     transform: translateX(50%);
-    opacity: 0.82;
+    opacity: 0.78;
   }
 
   .network-globe__svg {
     top: 5rem;
     right: auto;
     left: 50%;
-    width: 50rem;
+    width: 52rem;
     max-width: none;
     transform: translateX(-50%);
-    opacity: 0.42;
+    opacity: 0.4;
   }
 
-  .network-globe__route--secondary {
+  .network-globe__server--secondary,
+  .network-globe__federation--secondary {
     display: none;
   }
 
   .network-globe__sphere > * {
-    stroke: rgba(103, 232, 249, 0.105);
+    stroke: rgba(103, 232, 249, 0.075);
   }
 
   .network-globe__flow {
-    opacity: 0.5;
+    opacity: 0.48;
+  }
+
+  .network-globe__client-flow {
+    opacity: 0.42;
   }
 }
 
@@ -154,8 +213,9 @@ header.sticky > div > a[href="/"]:first-child::before {
     transition-duration: 0.01ms !important;
   }
 
-  .network-globe__flow {
+  .network-globe__flow,
+  .network-globe__client-flow {
     animation: none !important;
-    opacity: 0.22;
+    opacity: 0.2;
   }
 }

--- a/src/layout/SiteLayout.jsx
+++ b/src/layout/SiteLayout.jsx
@@ -1,5 +1,13 @@
 import Header from '../components/Header';
 import Footer from '../components/Footer';
+import NetworkGlobeBackground from '../components/NetworkGlobeBackground';
+
 export default function SiteLayout({ children }) {
-  return <div className="min-h-screen overflow-x-hidden bg-slate-950 text-slate-100"><a href="#main-content" className="sr-only z-50 rounded bg-cyan-300 p-3 text-slate-950 focus:not-sr-only focus:fixed focus:left-3 focus:top-3">Skip to content</a><Header /><main id="main-content">{children}</main><Footer /></div>;
+  return <div className="relative isolate min-h-screen overflow-x-hidden bg-slate-950 text-slate-100">
+    <NetworkGlobeBackground />
+    <a href="#main-content" className="sr-only z-50 rounded bg-cyan-300 p-3 text-slate-950 focus:not-sr-only focus:fixed focus:left-3 focus:top-3">Skip to content</a>
+    <Header />
+    <main id="main-content" className="relative z-10">{children}</main>
+    <div className="relative z-10"><Footer /></div>
+  </div>;
 }


### PR DESCRIPTION
## Summary
- add a lightweight decorative SVG federation background behind the primary site layout
- represent Matrix as a decentralized mesh of equal homeservers with attached user nodes
- animate client-to-homeserver and homeserver-to-homeserver traffic in both directions
- make every traffic loop phase-identical at its boundary to eliminate visible animation jumps
- reduce topology density and opacity on mobile while preserving the federated model
- respect `prefers-reduced-motion` by rendering traffic statically
- keep the background non-interactive and hidden from assistive technology
- add a focused component test for homeserver/user topology and normalized traffic paths

## Design notes
The treatment takes the connection-oriented feel of the legacy colonelkrud.com presentation but makes the network model specifically Matrix-oriented. The globe remains a quiet geographic motif; the primary visual hierarchy is now many independent homeservers, their local users, and a mesh of federation links. No node is visually designated as a central server.

## Seamless loop contract
Traffic paths use `pathLength="100"`. Federation dashes use `1.5 8.5` and client dashes use `0.8 9.2`, so both patterns repeat every exactly 10 normalized units. Each animation advances exactly +/-100 units with linear timing. The end frame is therefore phase-equivalent to the first frame and the infinite loop does not visibly reset.

## Performance
The background remains one fixed SVG with CSS stroke-dash animations. There are no requestAnimationFrame loops, canvas redraws, pointer listeners, WebGL contexts, or additional runtime packages. Mobile hides secondary homeservers and federation edges to reduce visual and rendering density.