### PR TITLE
Extend service status outage UI and impact messaging

### DIFF
--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -1,12 +1,39 @@
 import { ExternalLink, SiteLink } from './SiteLink';
 import MobileNavigation from './MobileNavigation';
+import { StatusStateSignal } from './StatusStateVisual';
 import { ACCOUNT_PORTAL_URL, ELEMENT_URL } from '../config/community';
+import { usePrefersReducedMotion } from '../hooks/usePrefersReducedMotion';
+import { stateLabel } from '../status/status';
+import { useLocalStatus } from '../status/useLocalStatus';
 
 const primaryLinks = [
   { label: 'Why CK Conflux', to: '/why-ck-conflux' }, { label: 'Matrix', to: '/matrix' },
   { label: 'Calls', to: '/calls' }, { label: 'Membership', to: '/membership' }, { label: 'Help', to: '/help' },
 ];
+
+function affectedSummary(components) {
+  if (!components.length) return 'Some CK Conflux services are affected.';
+  if (components.length === 1) {
+    const [component] = components;
+    return `${component.name} is ${stateLabel(component.state).toLowerCase()}.`;
+  }
+  if (components.length === 2) return `${components[0].name} and ${components[1].name} are affected.`;
+  return `${components[0].name}, ${components[1].name}, and ${components.length - 2} more service${components.length === 3 ? '' : 's'} are affected.`;
+}
+
 export default function Header() {
+  const status = useLocalStatus({ refreshIntervalMs: 60000 });
+  const prefersReducedMotion = usePrefersReducedMotion();
+  const affected = status.components.filter(({ state }) => state === 'degraded' || state === 'unavailable');
+  const incidentState = status.overall === 'unavailable' ? 'unavailable' : 'degraded';
+  const showIncident = status.phase === 'ready'
+    && !status.stale
+    && !status.noSnapshot
+    && (status.overall === 'degraded' || status.overall === 'unavailable');
+  const incidentClass = incidentState === 'unavailable'
+    ? 'border-rose-300/35 bg-rose-400/10 text-rose-50'
+    : 'border-amber-300/35 bg-amber-400/10 text-amber-50';
+
   return <header className="sticky top-0 z-30 border-b border-white/10 bg-slate-950/90 backdrop-blur">
     <div className="mx-auto flex w-full max-w-7xl items-center gap-3 px-4 py-3 sm:px-6 lg:px-8">
       <SiteLink to="/" className="mr-auto text-base font-semibold tracking-tight text-white sm:text-lg">CK Conflux</SiteLink>
@@ -18,5 +45,15 @@ export default function Header() {
       <SiteLink to="/join" className="hidden rounded-xl bg-cyan-400 px-3 py-2 text-sm font-semibold text-slate-950 shadow-lg shadow-cyan-500/25 transition motion-safe:hover:-translate-y-0.5 lg:inline-flex">Join CK Conflux</SiteLink>
       <MobileNavigation links={[{ label: 'Join CK Conflux', to: '/join' }, ...primaryLinks, { label: 'Open Element', to: ELEMENT_URL, external: true }, { label: 'My Account', to: ACCOUNT_PORTAL_URL, external: true }]} />
     </div>
+    {showIncident && <div className={`border-t ${incidentClass}`} role="alert" aria-live="assertive">
+      <div className="mx-auto flex w-full max-w-7xl items-center gap-3 px-4 py-2.5 sm:px-6 lg:px-8">
+        <StatusStateSignal state={incidentState} reducedMotion={prefersReducedMotion} />
+        <p className="min-w-0 flex-1 text-sm leading-5">
+          <strong className="font-semibold">{incidentState === 'unavailable' ? 'Service outage detected.' : 'Service disruption detected.'}</strong>{' '}
+          <span className="text-slate-100">{affectedSummary(affected)}</span>
+        </p>
+        <SiteLink to="/status" className="shrink-0 rounded-lg border border-white/15 bg-slate-950/20 px-3 py-1.5 text-xs font-semibold text-white transition hover:bg-white/10 sm:text-sm">View status</SiteLink>
+      </div>
+    </div>}
   </header>;
 }

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from 'react';
 import { ExternalLink, SiteLink } from './SiteLink';
 import MobileNavigation from './MobileNavigation';
 import { StatusStateSignal } from './StatusStateVisual';
@@ -21,7 +22,7 @@ function affectedSummary(components) {
   return `${components[0].name}, ${components[1].name}, and ${components.length - 2} more service${components.length === 3 ? '' : 's'} are affected.`;
 }
 
-export default function Header() {
+function IncidentStatusBanner() {
   const status = useLocalStatus({ refreshIntervalMs: 60000 });
   const prefersReducedMotion = usePrefersReducedMotion();
   const affected = status.components.filter(({ state }) => state === 'degraded' || state === 'unavailable');
@@ -34,6 +35,28 @@ export default function Header() {
     ? 'border-rose-300/35 bg-rose-400/10 text-rose-50'
     : 'border-amber-300/35 bg-amber-400/10 text-amber-50';
 
+  if (!showIncident) return null;
+
+  return <div className={`border-t ${incidentClass}`} role="alert" aria-live="assertive">
+    <div className="mx-auto flex w-full max-w-7xl items-center gap-3 px-4 py-2.5 sm:px-6 lg:px-8">
+      <StatusStateSignal state={incidentState} reducedMotion={prefersReducedMotion} />
+      <p className="min-w-0 flex-1 text-sm leading-5">
+        <strong className="font-semibold">{incidentState === 'unavailable' ? 'Service outage detected.' : 'Service disruption detected.'}</strong>{' '}
+        <span className="text-slate-100">{affectedSummary(affected)}</span>
+      </p>
+      <SiteLink to="/status" className="shrink-0 rounded-lg border border-white/15 bg-slate-950/20 px-3 py-1.5 text-xs font-semibold text-white transition hover:bg-white/10 sm:text-sm">View status</SiteLink>
+    </div>
+  </div>;
+}
+
+export default function Header() {
+  const [monitorStatus, setMonitorStatus] = useState(false);
+
+  useEffect(() => {
+    const timer = window.setTimeout(() => setMonitorStatus(true), 0);
+    return () => window.clearTimeout(timer);
+  }, []);
+
   return <header className="sticky top-0 z-30 border-b border-white/10 bg-slate-950/90 backdrop-blur">
     <div className="mx-auto flex w-full max-w-7xl items-center gap-3 px-4 py-3 sm:px-6 lg:px-8">
       <SiteLink to="/" className="mr-auto text-base font-semibold tracking-tight text-white sm:text-lg">CK Conflux</SiteLink>
@@ -45,15 +68,6 @@ export default function Header() {
       <SiteLink to="/join" className="hidden rounded-xl bg-cyan-400 px-3 py-2 text-sm font-semibold text-slate-950 shadow-lg shadow-cyan-500/25 transition motion-safe:hover:-translate-y-0.5 lg:inline-flex">Join CK Conflux</SiteLink>
       <MobileNavigation links={[{ label: 'Join CK Conflux', to: '/join' }, ...primaryLinks, { label: 'Open Element', to: ELEMENT_URL, external: true }, { label: 'My Account', to: ACCOUNT_PORTAL_URL, external: true }]} />
     </div>
-    {showIncident && <div className={`border-t ${incidentClass}`} role="alert" aria-live="assertive">
-      <div className="mx-auto flex w-full max-w-7xl items-center gap-3 px-4 py-2.5 sm:px-6 lg:px-8">
-        <StatusStateSignal state={incidentState} reducedMotion={prefersReducedMotion} />
-        <p className="min-w-0 flex-1 text-sm leading-5">
-          <strong className="font-semibold">{incidentState === 'unavailable' ? 'Service outage detected.' : 'Service disruption detected.'}</strong>{' '}
-          <span className="text-slate-100">{affectedSummary(affected)}</span>
-        </p>
-        <SiteLink to="/status" className="shrink-0 rounded-lg border border-white/15 bg-slate-950/20 px-3 py-1.5 text-xs font-semibold text-white transition hover:bg-white/10 sm:text-sm">View status</SiteLink>
-      </div>
-    </div>}
+    {monitorStatus && <IncidentStatusBanner />}
   </header>;
 }

--- a/src/components/Header.test.jsx
+++ b/src/components/Header.test.jsx
@@ -1,0 +1,71 @@
+import { act, cleanup, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { Router } from '../router/Router';
+import Header from './Header';
+
+const response = (body) => ({ ok: true, json: async () => body });
+
+function renderHeader() {
+  return render(<Router><Header /></Router>);
+}
+
+async function startStatusMonitor() {
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(1);
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+});
+
+describe('Header incident banner', () => {
+  it('shows the affected service for a fresh degraded state', async () => {
+    vi.useFakeTimers();
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(response({
+      status: 'degraded',
+      stale: false,
+      checks: { website: 'ok', login: 'ok', matrix: 'ok', media: 'ok', calls: 'ok', turn: 'down', membership: 'ok' },
+    })));
+
+    renderHeader();
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+    await startStatusMonitor();
+
+    expect(screen.getByRole('alert')).toHaveTextContent('Service disruption detected. Voice & video is degraded.');
+    expect(screen.getByRole('link', { name: 'View status' })).toHaveAttribute('href', '/status');
+  });
+
+  it('uses outage treatment when a service is unavailable', async () => {
+    vi.useFakeTimers();
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(response({
+      status: 'down',
+      stale: false,
+      checks: { website: 'ok', login: 'ok', matrix: 'down', media: 'ok', calls: 'ok', turn: 'ok', membership: 'ok' },
+    })));
+
+    renderHeader();
+    await startStatusMonitor();
+
+    expect(screen.getByRole('alert')).toHaveTextContent('Service outage detected. Messaging is unavailable.');
+    expect(screen.getByRole('alert')).toHaveClass('bg-rose-400/10');
+  });
+
+  it('does not announce an incident from stale status data', async () => {
+    vi.useFakeTimers();
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(response({
+      status: 'degraded',
+      stale: true,
+      checks: { website: 'ok', login: 'ok', matrix: 'ok', calls: 'ok', turn: 'down' },
+    })));
+
+    renderHeader();
+    await startStatusMonitor();
+
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  });
+});

--- a/src/components/StatusStateVisual.jsx
+++ b/src/components/StatusStateVisual.jsx
@@ -1,0 +1,87 @@
+import { motion as Motion } from 'framer-motion';
+import { AlertTriangle, CheckCircle2, CircleHelp, XCircle } from 'lucide-react';
+
+export const STATUS_STATE_META = {
+  operational: {
+    card: 'border-emerald-300/35 bg-emerald-400/[0.09] text-emerald-100 shadow-[0_18px_60px_-34px_rgba(52,211,153,0.55)]',
+    icon: 'border-emerald-300/45 bg-emerald-300/10 text-emerald-100',
+    ring: 'bg-emerald-300/25',
+    bar: 'bg-emerald-300',
+    glow: 'bg-emerald-400/20',
+    pill: 'border-emerald-300/30 bg-emerald-400/10 text-emerald-100',
+  },
+  degraded: {
+    card: 'border-amber-300/40 bg-amber-400/10 text-amber-100 shadow-[0_18px_60px_-34px_rgba(251,191,36,0.55)]',
+    icon: 'border-amber-300/50 bg-amber-300/10 text-amber-100',
+    ring: 'bg-amber-300/25',
+    bar: 'bg-amber-300',
+    glow: 'bg-amber-400/20',
+    pill: 'border-amber-300/35 bg-amber-400/10 text-amber-100',
+  },
+  unavailable: {
+    card: 'border-rose-300/40 bg-rose-400/10 text-rose-100 shadow-[0_18px_60px_-32px_rgba(251,113,133,0.65)]',
+    icon: 'border-rose-300/50 bg-rose-300/10 text-rose-100',
+    ring: 'bg-rose-300/30',
+    bar: 'bg-rose-300',
+    glow: 'bg-rose-400/25',
+    pill: 'border-rose-300/35 bg-rose-400/10 text-rose-100',
+  },
+  unknown: {
+    card: 'border-slate-300/30 bg-slate-400/10 text-slate-100',
+    icon: 'border-slate-300/40 bg-slate-300/10 text-slate-100',
+    ring: 'bg-slate-300/20',
+    bar: 'bg-slate-300',
+    glow: 'bg-slate-400/15',
+    pill: 'border-slate-300/30 bg-slate-400/10 text-slate-100',
+  },
+};
+
+const STATE_ICONS = {
+  operational: CheckCircle2,
+  degraded: AlertTriangle,
+  unavailable: XCircle,
+  unknown: CircleHelp,
+};
+
+const SIGNAL_MOTION = {
+  operational: { scale: [1, 1.18, 1], opacity: [0.2, 0.04, 0.2], duration: 3.6 },
+  degraded: { scale: [1, 1.22, 1], opacity: [0.24, 0.05, 0.24], duration: 2.4 },
+  unavailable: { scale: [1, 1.3, 1], opacity: [0.32, 0.03, 0.32], duration: 1.55 },
+  unknown: { scale: [1, 1.14, 1], opacity: [0.16, 0.04, 0.16], duration: 4.2 },
+};
+
+export function StatusStateSignal({ state, large = false, reducedMotion = false }) {
+  const Icon = STATE_ICONS[state] ?? CircleHelp;
+  const meta = STATUS_STATE_META[state] ?? STATUS_STATE_META.unknown;
+  const signalMotion = SIGNAL_MOTION[state] ?? SIGNAL_MOTION.unknown;
+  const size = large ? 'h-12 w-12' : 'h-9 w-9';
+  const iconSize = large ? 24 : 18;
+
+  return <span aria-hidden="true" className={`relative flex shrink-0 items-center justify-center ${size}`}>
+    {reducedMotion
+      ? <span className={`absolute inset-0 rounded-full ${meta.ring}`} />
+      : <Motion.span
+          className={`absolute inset-0 rounded-full ${meta.ring}`}
+          animate={{ scale: signalMotion.scale, opacity: signalMotion.opacity }}
+          transition={{ duration: signalMotion.duration, repeat: Infinity, ease: 'easeInOut' }}
+        />}
+    <span className={`relative flex h-full w-full items-center justify-center rounded-full border ${meta.icon}`}>
+      <Icon size={iconSize} strokeWidth={2.1} />
+    </span>
+  </span>;
+}
+
+export function StatusAmbientGlow({ state, reducedMotion = false, className = '' }) {
+  const meta = STATUS_STATE_META[state] ?? STATUS_STATE_META.unknown;
+  const duration = state === 'unavailable' ? 2.4 : state === 'degraded' ? 3.4 : 4.8;
+  const classes = `pointer-events-none absolute rounded-full blur-3xl ${meta.glow} ${className}`;
+
+  if (reducedMotion) return <span aria-hidden="true" className={classes} />;
+
+  return <Motion.span
+    aria-hidden="true"
+    className={classes}
+    animate={{ scale: [1, 1.08, 1], opacity: [0.45, 0.75, 0.45] }}
+    transition={{ duration, repeat: Infinity, ease: 'easeInOut' }}
+  />;
+}

--- a/src/components/StatusSummary.jsx
+++ b/src/components/StatusSummary.jsx
@@ -1,6 +1,12 @@
 import { Link } from '../router/Router';
 import { statusHeadline } from '../status/status';
 import { useLocalStatus } from '../status/useLocalStatus';
+import { usePrefersReducedMotion } from '../hooks/usePrefersReducedMotion';
+import {
+  StatusAmbientGlow,
+  STATUS_STATE_META,
+  StatusStateSignal,
+} from './StatusStateVisual';
 
 function relativeUpdateLabel(value) {
   const date = value ? new Date(value) : null;
@@ -15,6 +21,7 @@ function relativeUpdateLabel(value) {
 
 export default function StatusSummary() {
   const status = useLocalStatus({ refreshIntervalMs: 60000 });
+  const prefersReducedMotion = usePrefersReducedMotion();
   const affected = status.components.filter(({ state }) => state === 'degraded' || state === 'unavailable');
   const snapshotMissing = status.phase === 'ready' && status.noSnapshot;
 
@@ -53,14 +60,26 @@ export default function StatusSummary() {
   const staleNotice = snapshotMissing
     ? 'A status snapshot is not available yet.'
     : 'Showing the last reported service status.';
+  const displayState = status.phase === 'error' || status.stale
+    ? 'degraded'
+    : status.phase === 'ready'
+      ? status.overall
+      : 'unknown';
+  const meta = STATUS_STATE_META[displayState] ?? STATUS_STATE_META.unknown;
 
-  return <div className="min-h-24 rounded-2xl border border-white/10 bg-white/5 p-5">
-    <p className="text-xs font-semibold uppercase tracking-[0.18em] text-cyan-200">{status.stale ? 'Service status' : 'Live service status'}</p>
-    <p className="mt-2 text-lg font-semibold text-white" aria-live="polite">{message}</p>
-    {supporting && <p className="mt-1 text-sm text-slate-300">{supporting}</p>}
-    {freshness && <p className="mt-1 text-sm text-slate-400">{freshness}</p>}
-    {status.stale && <p className="mt-1 text-sm font-semibold text-amber-100" role="status">{staleNotice}</p>}
-    {status.phase === 'ready' && !status.noSnapshot && status.refreshError && <p className="mt-1 text-sm font-semibold text-amber-100" role="status">Unable to refresh status. Showing the last known update.</p>}
-    <Link to="/status" className="mt-3 inline-flex text-sm font-semibold text-cyan-200 hover:text-cyan-100">View details →</Link>
+  return <div data-state={displayState} className={`relative min-h-24 overflow-hidden rounded-2xl border p-5 ${meta.card}`}>
+    <StatusAmbientGlow state={displayState} reducedMotion={prefersReducedMotion} className="-right-12 -top-16 h-40 w-40" />
+    <div className="relative flex items-start gap-3">
+      <StatusStateSignal state={displayState} reducedMotion={prefersReducedMotion} />
+      <div className="min-w-0 flex-1">
+        <p className="text-xs font-semibold uppercase tracking-[0.18em] text-cyan-100">{status.stale ? 'Service status' : 'Live service status'}</p>
+        <p className="mt-2 text-lg font-semibold text-white" aria-live="polite">{message}</p>
+        {supporting && <p className="mt-1 text-sm text-slate-200">{supporting}</p>}
+        {freshness && <p className="mt-1 text-sm text-slate-300">{freshness}</p>}
+        {status.stale && <p className="mt-1 text-sm font-semibold text-amber-100" role="status">{staleNotice}</p>}
+        {status.phase === 'ready' && !status.noSnapshot && status.refreshError && <p className="mt-1 text-sm font-semibold text-amber-100" role="status">Unable to refresh status. Showing the last known update.</p>}
+        <Link to="/status" className="mt-3 inline-flex text-sm font-semibold text-cyan-100 hover:text-white">View details →</Link>
+      </div>
+    </div>
   </div>;
 }

--- a/src/pages/Status.jsx
+++ b/src/pages/Status.jsx
@@ -1,9 +1,15 @@
 import { motion as Motion } from 'framer-motion';
-import { AlertTriangle, CheckCircle2, CircleHelp, RefreshCw, XCircle } from 'lucide-react';
+import { RefreshCw } from 'lucide-react';
 import { ExternalLink } from '../components/SiteLink';
+import {
+  StatusAmbientGlow,
+  STATUS_STATE_META,
+  StatusStateSignal,
+} from '../components/StatusStateVisual';
 import { usePrefersReducedMotion } from '../hooks/usePrefersReducedMotion';
 import {
   INDEPENDENT_STATUS_URL,
+  serviceImpact,
   stateLabel,
   statusHeadline,
 } from '../status/status';
@@ -14,60 +20,6 @@ const DETAILS = {
   degraded: 'CK Conflux is available, but one or more services may not work normally.',
   unavailable: 'One or more CK Conflux services are currently unavailable.',
   unknown: 'Some service checks returned an unknown state.',
-};
-const IMPACT = {
-  messaging: 'Sending or receiving messages may be delayed or fail.',
-  signin: 'Signing in or creating an account may fail.',
-  calls: 'Calls may fail to connect or may be disrupted.',
-  media: 'Uploading or retrieving files and images may fail.',
-  account: 'My Account or membership-related workflows may be unavailable.',
-  website: 'CK Conflux public web pages may be partially unavailable.',
-};
-const STATE_META = {
-  operational: {
-    card: 'border-emerald-300/35 bg-emerald-400/[0.09] text-emerald-100 shadow-[0_18px_60px_-34px_rgba(52,211,153,0.55)]',
-    icon: 'border-emerald-300/45 bg-emerald-300/10 text-emerald-100',
-    ring: 'bg-emerald-300/25',
-    bar: 'bg-emerald-300',
-    glow: 'bg-emerald-400/20',
-    pill: 'border-emerald-300/30 bg-emerald-400/10 text-emerald-100',
-  },
-  degraded: {
-    card: 'border-amber-300/40 bg-amber-400/10 text-amber-100 shadow-[0_18px_60px_-34px_rgba(251,191,36,0.55)]',
-    icon: 'border-amber-300/50 bg-amber-300/10 text-amber-100',
-    ring: 'bg-amber-300/25',
-    bar: 'bg-amber-300',
-    glow: 'bg-amber-400/20',
-    pill: 'border-amber-300/35 bg-amber-400/10 text-amber-100',
-  },
-  unavailable: {
-    card: 'border-rose-300/40 bg-rose-400/10 text-rose-100 shadow-[0_18px_60px_-32px_rgba(251,113,133,0.65)]',
-    icon: 'border-rose-300/50 bg-rose-300/10 text-rose-100',
-    ring: 'bg-rose-300/30',
-    bar: 'bg-rose-300',
-    glow: 'bg-rose-400/25',
-    pill: 'border-rose-300/35 bg-rose-400/10 text-rose-100',
-  },
-  unknown: {
-    card: 'border-slate-300/30 bg-slate-400/10 text-slate-100',
-    icon: 'border-slate-300/40 bg-slate-300/10 text-slate-100',
-    ring: 'bg-slate-300/20',
-    bar: 'bg-slate-300',
-    glow: 'bg-slate-400/15',
-    pill: 'border-slate-300/30 bg-slate-400/10 text-slate-100',
-  },
-};
-const STATE_ICONS = {
-  operational: CheckCircle2,
-  degraded: AlertTriangle,
-  unavailable: XCircle,
-  unknown: CircleHelp,
-};
-const SIGNAL_MOTION = {
-  operational: { scale: [1, 1.18, 1], opacity: [0.2, 0.04, 0.2], duration: 3.6 },
-  degraded: { scale: [1, 1.22, 1], opacity: [0.24, 0.05, 0.24], duration: 2.4 },
-  unavailable: { scale: [1, 1.3, 1], opacity: [0.32, 0.03, 0.32], duration: 1.55 },
-  unknown: { scale: [1, 1.14, 1], opacity: [0.16, 0.04, 0.16], duration: 4.2 },
 };
 
 function relativeTime(value) {
@@ -92,30 +44,9 @@ function Freshness({ status }) {
   </p>;
 }
 
-function StateSignal({ state, large = false, reducedMotion = false }) {
-  const Icon = STATE_ICONS[state] ?? CircleHelp;
-  const meta = STATE_META[state] ?? STATE_META.unknown;
-  const signalMotion = SIGNAL_MOTION[state] ?? SIGNAL_MOTION.unknown;
-  const size = large ? 'h-12 w-12' : 'h-9 w-9';
-  const iconSize = large ? 24 : 18;
-
-  return <span aria-hidden="true" className={`relative flex shrink-0 items-center justify-center ${size}`}>
-    {reducedMotion
-      ? <span className={`absolute inset-0 rounded-full ${meta.ring}`} />
-      : <Motion.span
-          className={`absolute inset-0 rounded-full ${meta.ring}`}
-          animate={{ scale: signalMotion.scale, opacity: signalMotion.opacity }}
-          transition={{ duration: signalMotion.duration, repeat: Infinity, ease: 'easeInOut' }}
-        />}
-    <span className={`relative flex h-full w-full items-center justify-center rounded-full border ${meta.icon}`}>
-      <Icon size={iconSize} strokeWidth={2.1} />
-    </span>
-  </span>;
-}
-
 function StateCount({ state, count }) {
   if (!count) return null;
-  const meta = STATE_META[state] ?? STATE_META.unknown;
+  const meta = STATUS_STATE_META[state] ?? STATUS_STATE_META.unknown;
   return <span className={`inline-flex items-center gap-2 rounded-full border px-3 py-1 text-xs font-semibold ${meta.pill}`}>
     <span aria-hidden="true" className={`h-1.5 w-1.5 rounded-full ${meta.bar}`} />
     {count} {stateLabel(state).toLowerCase()}
@@ -129,7 +60,7 @@ export default function Status() {
   const snapshotMissing = status.phase === 'ready' && status.noSnapshot;
   const affectedCount = status.components.filter(({ state }) => state === 'degraded' || state === 'unavailable').length;
   const hasUnknownComponent = status.components.some(({ state }) => state === 'unknown');
-  const websiteOperational = status.components.some(({ id, state }) => id === 'website' && state === 'operational');
+  const webOperational = status.components.some(({ id, state }) => id === 'website' && state === 'operational');
   const stateCounts = status.components.reduce((counts, component) => {
     counts[component.state] = (counts[component.state] ?? 0) + 1;
     return counts;
@@ -143,15 +74,15 @@ export default function Status() {
     ? 'Current service status is not available yet.'
     : status.stale
       ? `Showing the last reported service status. Last reported state: ${statusHeadline(status.overall)}.`
-      : status.overall === 'unavailable' && websiteOperational
+      : status.overall === 'unavailable' && webOperational
         ? affectedCount > 1
-          ? `${affectedCount} CK Conflux services are currently affected. The website remains available.`
-          : 'One or more CK Conflux services are currently unavailable. The website remains available.'
+          ? `${affectedCount} CK Conflux services are currently affected. Web services remain available.`
+          : 'One or more CK Conflux services are currently unavailable. Web services remain available.'
         : status.overall === 'unknown' && !hasUnknownComponent
-        ? 'Status information is incomplete; the status feed did not confirm a complete platform state.'
-        : DETAILS[status.overall];
+          ? 'Status information is incomplete; the status feed did not confirm a complete platform state.'
+          : DETAILS[status.overall];
   const displayState = status.stale ? 'degraded' : status.overall;
-  const statusMeta = STATE_META[displayState] ?? STATE_META.unknown;
+  const statusMeta = STATUS_STATE_META[displayState] ?? STATUS_STATE_META.unknown;
   const staleNotice = snapshotMissing
     ? 'A status snapshot is not available yet.'
     : 'Showing the last reported service status.';
@@ -165,12 +96,10 @@ export default function Status() {
     <section className="mt-8" aria-labelledby="overall-status">
       <div className="flex flex-wrap items-center justify-between gap-3"><h2 id="overall-status" className="text-sm font-semibold uppercase tracking-[0.16em] text-slate-300">Overall CK Conflux status</h2><button type="button" onClick={status.refresh} disabled={status.isRefreshing} className="inline-flex items-center gap-2 rounded-lg border border-white/20 bg-white/[0.03] px-4 py-2 text-sm font-semibold text-white transition hover:border-cyan-200 hover:bg-cyan-300/[0.05] disabled:cursor-wait disabled:opacity-60"><RefreshCw aria-hidden="true" size={16} className={status.isRefreshing ? 'animate-spin' : ''} />{status.isRefreshing ? 'Refreshing…' : 'Refresh'}</button></div>
       {status.phase === 'loading' && <div className="mt-4 min-h-32 rounded-2xl border border-white/10 bg-white/5 p-6 text-slate-300" role="status">Checking CK Conflux service health…</div>}
-      {error && <div className="mt-4 rounded-2xl border border-amber-300/40 bg-amber-400/10 p-6" role="alert"><div className="flex items-start gap-4"><StateSignal state="degraded" large reducedMotion={prefersReducedMotion} /><div><h3 className="text-xl font-semibold text-white">Status information unavailable</h3><p className="mt-2 leading-7 text-slate-200">We couldn't load the current service status.</p><button type="button" onClick={status.refresh} className="mt-4 rounded-lg border border-white/20 px-4 py-2 text-sm font-semibold text-white hover:border-cyan-200">Retry</button></div></div></div>}
+      {error && <div className="mt-4 rounded-2xl border border-amber-300/40 bg-amber-400/10 p-6" role="alert"><div className="flex items-start gap-4"><StatusStateSignal state="degraded" large reducedMotion={prefersReducedMotion} /><div><h3 className="text-xl font-semibold text-white">Status information unavailable</h3><p className="mt-2 leading-7 text-slate-200">We couldn't load the current service status.</p><button type="button" onClick={status.refresh} className="mt-4 rounded-lg border border-white/20 px-4 py-2 text-sm font-semibold text-white hover:border-cyan-200">Retry</button></div></div></div>}
       {status.phase === 'ready' && <Motion.div {...entrance} className={`relative mt-4 overflow-hidden rounded-2xl border p-5 sm:p-6 ${statusMeta.card}`}>
-        {prefersReducedMotion
-          ? <span aria-hidden="true" className={`pointer-events-none absolute -right-16 -top-24 h-56 w-56 rounded-full blur-3xl ${statusMeta.glow}`} />
-          : <Motion.span aria-hidden="true" className={`pointer-events-none absolute -right-16 -top-24 h-56 w-56 rounded-full blur-3xl ${statusMeta.glow}`} animate={{ scale: [1, 1.08, 1], opacity: [0.45, 0.75, 0.45] }} transition={{ duration: displayState === 'unavailable' ? 2.4 : 4.8, repeat: Infinity, ease: 'easeInOut' }} />}
-        <div className="relative flex items-start gap-4"><StateSignal state={displayState} large reducedMotion={prefersReducedMotion} /><div><h3 className="text-2xl font-semibold text-white" aria-live="polite" aria-atomic="true">{headline}</h3><p className="mt-2 max-w-3xl leading-7 text-slate-200">{detail}</p><div className="mt-3"><Freshness status={status} /></div>{status.stale && <p className="mt-3 font-semibold text-amber-100" role="status">{staleNotice}</p>}{status.refreshError && <p className="mt-3 font-semibold text-amber-100" role="status">Unable to refresh status. Showing the last known update.</p>}{status.isRefreshing && <p className="mt-3 text-sm text-slate-300" role="status">Refreshing status…</p>}</div></div>
+        <StatusAmbientGlow state={displayState} reducedMotion={prefersReducedMotion} className="-right-16 -top-24 h-56 w-56" />
+        <div className="relative flex items-start gap-4"><StatusStateSignal state={displayState} large reducedMotion={prefersReducedMotion} /><div><h3 className="text-2xl font-semibold text-white" aria-live="polite" aria-atomic="true">{headline}</h3><p className="mt-2 max-w-3xl leading-7 text-slate-200">{detail}</p><div className="mt-3"><Freshness status={status} /></div>{status.stale && <p className="mt-3 font-semibold text-amber-100" role="status">{staleNotice}</p>}{status.refreshError && <p className="mt-3 font-semibold text-amber-100" role="status">Unable to refresh status. Showing the last known update.</p>}{status.isRefreshing && <p className="mt-3 text-sm text-slate-300" role="status">Refreshing status…</p>}</div></div>
       </Motion.div>}
     </section>
 
@@ -178,13 +107,13 @@ export default function Status() {
       <div className="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between"><div><h2 id="services-status" className="text-2xl font-semibold text-white">Services</h2><p className="mt-2 text-slate-300">Health is grouped by the CK Conflux features people use.</p></div><div className="flex flex-wrap gap-2" aria-label="Service state summary"><StateCount state="operational" count={stateCounts.operational} /><StateCount state="degraded" count={stateCounts.degraded} /><StateCount state="unavailable" count={stateCounts.unavailable} /><StateCount state="unknown" count={stateCounts.unknown} /></div></div>
       <ul className="mt-5 grid gap-4 sm:grid-cols-2 lg:grid-cols-3">{status.components.map((component, index) => {
         const affected = component.state === 'degraded' || component.state === 'unavailable';
-        const meta = STATE_META[component.state] ?? STATE_META.unknown;
+        const meta = STATUS_STATE_META[component.state] ?? STATUS_STATE_META.unknown;
         const itemEntrance = prefersReducedMotion
           ? {}
           : { initial: { opacity: 0, y: 8 }, animate: { opacity: 1, y: 0 }, transition: { duration: 0.3, delay: Math.min(index * 0.055, 0.3), ease: 'easeOut' } };
         return <Motion.li {...itemEntrance} key={component.id} data-state={component.state} className={`relative overflow-hidden rounded-2xl border p-4 sm:p-5 ${meta.card}`}>
           <span aria-hidden="true" className={`absolute inset-y-0 left-0 w-1 ${meta.bar}`} />
-          <div className="flex items-center justify-between gap-4"><span className="font-medium text-white">{component.name}</span><strong className="flex items-center gap-2 text-sm"><StateSignal state={component.state} reducedMotion={prefersReducedMotion} />{stateLabel(component.state)}</strong></div>{affected && <p className="mt-3 text-sm leading-6 text-slate-200">{IMPACT[component.id] || 'This service may not work normally.'}</p>}
+          <div className="flex items-center justify-between gap-4"><span className="font-medium text-white">{component.name}</span><strong className="flex items-center gap-2 text-sm"><StatusStateSignal state={component.state} reducedMotion={prefersReducedMotion} />{stateLabel(component.state)}</strong></div>{affected && <p className="mt-3 text-sm leading-6 text-slate-200">{serviceImpact(component, status)}</p>}
         </Motion.li>;
       })}</ul>
     </section>}

--- a/src/pages/Status.test.jsx
+++ b/src/pages/Status.test.jsx
@@ -22,10 +22,10 @@ describe('Status page', () => {
     render(<Status />);
 
     expect(await screen.findByRole('heading', { name: 'Service outage detected' })).toBeInTheDocument();
-    expect(screen.getByText(/website remains available/i)).toBeInTheDocument();
-    expect(screen.getByText('5 CK Conflux services are currently affected. The website remains available.')).toBeInTheDocument();
+    expect(screen.getByText(/web services remain available/i)).toBeInTheDocument();
+    expect(screen.getByText('5 CK Conflux services are currently affected. Web services remain available.')).toBeInTheDocument();
 
-    const website = screen.getByText('Website').closest('li');
+    const website = screen.getByText('Web services').closest('li');
     const signin = screen.getByText('Sign in').closest('li');
     expect(website).toHaveTextContent('Operational');
     expect(website).toHaveAttribute('data-state', 'operational');
@@ -46,6 +46,30 @@ describe('Status page', () => {
     expect(screen.queryByText('Synapse degraded')).not.toBeInTheDocument();
   });
 
+  it('explains a TURN-only disruption without claiming Matrix messaging is down', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(response({
+      status: 'degraded',
+      stale: false,
+      checks: {
+        website: 'ok',
+        login: 'ok',
+        matrix: 'ok',
+        media: 'ok',
+        calls: 'ok',
+        turn: 'down',
+        membership: 'ok',
+      },
+    }, false, 503)));
+    render(<Status />);
+
+    expect(await screen.findByRole('heading', { name: 'Some services are degraded' })).toBeInTheDocument();
+    const calls = screen.getByText('Voice & video').closest('li');
+    expect(calls).toHaveAttribute('data-state', 'degraded');
+    expect(calls).toHaveTextContent('The Matrix homeserver and MatrixRTC core remain available, but TURN is unavailable. Legacy calling is degraded and calls may fail in restrictive network conditions.');
+    expect(screen.getByText('Messaging').closest('li')).toHaveAttribute('data-state', 'operational');
+    expect(screen.queryByText('Turn')).not.toBeInTheDocument();
+  });
+
   it('does not overstate the outage breadth when only one component is affected', async () => {
     vi.stubGlobal('fetch', vi.fn().mockResolvedValue(response({
       status: 'down',
@@ -54,7 +78,7 @@ describe('Status page', () => {
     render(<Status />);
 
     expect(await screen.findByRole('heading', { name: 'Service outage detected' })).toBeInTheDocument();
-    expect(screen.getByText('One or more CK Conflux services are currently unavailable. The website remains available.')).toBeInTheDocument();
+    expect(screen.getByText('One or more CK Conflux services are currently unavailable. Web services remain available.')).toBeInTheDocument();
     expect(screen.queryByText(/Several CK Conflux services/i)).not.toBeInTheDocument();
   });
 
@@ -124,6 +148,6 @@ describe('Status page', () => {
     expect(await screen.findByRole('heading', { name: 'Status information incomplete' })).toBeInTheDocument();
     expect(screen.getByText('Status information is incomplete; the status feed did not confirm a complete platform state.')).toBeInTheDocument();
     expect(screen.queryByText('Some service checks returned an unknown state.')).not.toBeInTheDocument();
-    expect(screen.getByText('Website').closest('li')).toHaveTextContent('Operational');
+    expect(screen.getByText('Web services').closest('li')).toHaveTextContent('Operational');
   });
 });

--- a/src/status/status.js
+++ b/src/status/status.js
@@ -160,7 +160,7 @@ export function serviceImpact(component, status) {
 
   if (component.id === 'messaging') {
     return unavailable
-      ? 'The Matrix homeserver is unavailable. Sending and receiving messages may fail until service is restored.'
+      ? 'The Matrix homeserver is unavailable. Messages may be delayed or fail until service is restored.'
       : 'The Matrix homeserver is degraded. Messages may be delayed or fail intermittently.';
   }
 

--- a/src/status/status.js
+++ b/src/status/status.js
@@ -1,10 +1,10 @@
 const COMPONENTS = {
   messaging: { name: 'Messaging', order: 1, aliases: ['matrix', 'messaging', 'homeserver', 'synapse'] },
   signin: { name: 'Sign in', order: 2, aliases: ['authentication', 'auth', 'signin', 'login'] },
-  calls: { name: 'Voice & video', order: 3, aliases: ['calls', 'call', 'matrixrtc', 'livekit', 'turnify'] },
+  calls: { name: 'Voice & video', order: 3, aliases: ['calls', 'call', 'matrixrtc', 'livekit', 'turnify', 'turn'] },
   media: { name: 'Media & uploads', order: 4, aliases: ['media', 'uploads'] },
   account: { name: 'Account & membership', order: 5, aliases: ['membership', 'account', 'accounts'] },
-  website: { name: 'Website', order: 6, aliases: ['website', 'web', 'frontend'] },
+  website: { name: 'Web services', order: 6, aliases: ['website', 'web', 'frontend'] },
 };
 
 const ALIASES = Object.entries(COMPONENTS)
@@ -59,6 +59,13 @@ function normalizeComponent(key) {
   return { id: `other-${normalized || 'unknown'}`, name, order: 100 };
 }
 
+function componentState(key, value, componentId) {
+  const state = healthState(value);
+  const check = normalizedKey(key);
+  if (componentId === 'calls' && ['turn', 'turnify'].includes(check) && state === 'unavailable') return 'degraded';
+  return state;
+}
+
 function overallState(states) {
   if (!states.length) return 'unknown';
   return states.reduce((worst, state) => STATE_PRIORITY[state] > STATE_PRIORITY[worst] ? state : worst, 'operational');
@@ -97,10 +104,13 @@ export function parseStatus(payload) {
     : Object.entries(source);
   if (!entries.length && !noSnapshot) return null;
 
+  const checks = {};
   const byId = new Map();
   entries.forEach(([key, value]) => {
+    const check = normalizedKey(key);
+    if (check) checks[check] = healthState(value);
     const component = normalizeComponent(key);
-    const next = { id: component.id, name: component.name, state: healthState(value), order: component.order };
+    const next = { id: component.id, name: component.name, state: componentState(key, value, component.id), order: component.order };
     const current = byId.get(component.id);
     if (!current || STATE_PRIORITY[next.state] > STATE_PRIORITY[current.state]) byId.set(component.id, next);
   });
@@ -124,12 +134,95 @@ export function parseStatus(payload) {
   return {
     overall,
     components,
+    checks,
     generatedAt,
     snapshotAgeSeconds,
     stale: payload.stale === true,
     messages,
     noSnapshot,
   };
+}
+
+function componentIsOperational(status, id) {
+  return status.components?.some((component) => component.id === id && component.state === 'operational');
+}
+
+function firstCheck(status, keys) {
+  for (const key of keys) {
+    if (status.checks?.[key]) return status.checks[key];
+  }
+  return null;
+}
+
+export function serviceImpact(component, status) {
+  const unavailable = component.state === 'unavailable';
+  const messagingOperational = componentIsOperational(status, 'messaging');
+
+  if (component.id === 'messaging') {
+    return unavailable
+      ? 'The Matrix homeserver is unavailable. Sending and receiving messages may fail until service is restored.'
+      : 'The Matrix homeserver is degraded. Messages may be delayed or fail intermittently.';
+  }
+
+  if (component.id === 'signin') {
+    return unavailable
+      ? 'Sign-in services are unavailable. Existing sessions may continue to work, but new sign-ins or account creation may fail.'
+      : 'Sign-in services are degraded. New sign-ins or account creation may fail intermittently.';
+  }
+
+  if (component.id === 'calls') {
+    const coreState = firstCheck(status, ['calls', 'matrixrtc', 'livekit']);
+    const turnState = firstCheck(status, ['turn', 'turnify']);
+    const turnAffected = turnState === 'degraded' || turnState === 'unavailable';
+
+    if (coreState === 'operational' && turnAffected) {
+      const prefix = messagingOperational
+        ? 'The Matrix homeserver and MatrixRTC core remain available, but '
+        : 'MatrixRTC core remains available, but ';
+      const turnDescription = turnState === 'unavailable' ? 'TURN is unavailable.' : 'TURN is degraded.';
+      return `${prefix}${turnDescription} Legacy calling is degraded and calls may fail in restrictive network conditions.`;
+    }
+
+    if (coreState === 'unavailable') {
+      return messagingOperational
+        ? 'Messaging remains available, but MatrixRTC calling is unavailable. Voice and video calls may fail to start or connect.'
+        : 'MatrixRTC calling is unavailable. Voice and video calls may fail to start or connect.';
+    }
+
+    if (turnAffected) {
+      return 'Voice and video calling is degraded, including TURN-assisted connectivity. Calls may fail in restrictive network conditions.';
+    }
+
+    return unavailable
+      ? 'Voice and video calling is unavailable. Calls may fail to start or connect.'
+      : 'Voice and video calling is degraded. Calls may fail to connect or may be disrupted.';
+  }
+
+  if (component.id === 'media') {
+    return messagingOperational
+      ? `${unavailable ? 'Messaging remains available, but media services are unavailable.' : 'Messaging remains available, but media services are degraded.'} Uploading or retrieving files and images may fail.`
+      : unavailable
+        ? 'Media services are unavailable. Uploading or retrieving files and images may fail.'
+        : 'Media services are degraded. Uploading or retrieving files and images may fail intermittently.';
+  }
+
+  if (component.id === 'account') {
+    return messagingOperational
+      ? `${unavailable ? 'Messaging remains available, but account and membership services are unavailable.' : 'Messaging remains available, but account and membership services are degraded.'} My Account and membership workflows may fail.`
+      : unavailable
+        ? 'Account and membership services are unavailable. My Account and membership workflows may fail.'
+        : 'Account and membership services are degraded. My Account and membership workflows may fail intermittently.';
+  }
+
+  if (component.id === 'website') {
+    return messagingOperational
+      ? `${unavailable ? 'Public web services are unavailable.' : 'Public web services are degraded.'} Matrix clients may still work while messaging remains operational.`
+      : unavailable
+        ? 'Public web services are unavailable. Some CK Conflux web experiences may not load.'
+        : 'Public web services are degraded. Some CK Conflux web experiences may not load normally.';
+  }
+
+  return unavailable ? 'This service is unavailable and may not work.' : 'This service is degraded and may not work normally.';
 }
 
 export const stateLabel = (state) => ({ operational: 'Operational', degraded: 'Degraded', unavailable: 'Unavailable', unknown: 'Unknown' }[state] ?? 'Unknown');

--- a/src/status/status.test.js
+++ b/src/status/status.test.js
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { parseStatus } from './status';
+import { parseStatus, serviceImpact } from './status';
 
 describe('status payload normalization', () => {
   it('normalizes labels, keeps messaging and calls distinct, and uses preferred order', () => {
@@ -11,7 +11,7 @@ describe('status payload normalization', () => {
       { id: 'calls', name: 'Voice & video', state: 'degraded' },
       { id: 'media', name: 'Media & uploads', state: 'operational' },
       { id: 'account', name: 'Account & membership', state: 'operational' },
-      { id: 'website', name: 'Website', state: 'operational' },
+      { id: 'website', name: 'Web services', state: 'operational' },
     ]);
   });
 
@@ -28,6 +28,7 @@ describe('status payload normalization', () => {
         matrix: 'ok',
         media: 'ok',
         calls: 'ok',
+        turn: 'ok',
         membership: 'ok',
       },
     });
@@ -37,6 +38,30 @@ describe('status payload normalization', () => {
     expect(parsed.snapshotAgeSeconds).toBe(12.4);
     expect(parsed.generatedAt).toBe('2026-08-30T18:00:00Z');
     expect(parsed.components).toHaveLength(6);
+    expect(parsed.checks.turn).toBe('operational');
+  });
+
+  it('treats a TURN-only outage as degraded calling and preserves the underlying impact', () => {
+    const parsed = parseStatus({
+      status: 'degraded',
+      stale: false,
+      checks: {
+        website: 'ok',
+        login: 'ok',
+        matrix: 'ok',
+        media: 'ok',
+        calls: 'ok',
+        turn: 'down',
+        membership: 'ok',
+      },
+    });
+
+    const calls = parsed.components.find(({ id }) => id === 'calls');
+    expect(parsed.overall).toBe('degraded');
+    expect(calls).toEqual({ id: 'calls', name: 'Voice & video', state: 'degraded' });
+    expect(parsed.components.some(({ id }) => id === 'other-turn')).toBe(false);
+    expect(parsed.checks.turn).toBe('unavailable');
+    expect(serviceImpact(calls, parsed)).toBe('The Matrix homeserver and MatrixRTC core remain available, but TURN is unavailable. Legacy calling is degraded and calls may fail in restrictive network conditions.');
   });
 
   it('preserves a stale healthy snapshot instead of treating the response as fresh', () => {
@@ -67,6 +92,7 @@ describe('status payload normalization', () => {
     expect(parsed).toMatchObject({
       overall: 'unknown',
       components: [],
+      checks: {},
       generatedAt: null,
       snapshotAgeSeconds: null,
       stale: true,
@@ -123,7 +149,7 @@ describe('status payload normalization', () => {
     expect(parsed.generatedAt).toBe('2026-08-30T12:00:00Z');
     expect(parsed.components).toEqual([
       { id: 'messaging', name: 'Messaging', state: 'degraded' },
-      { id: 'website', name: 'Website', state: 'operational' },
+      { id: 'website', name: 'Web services', state: 'operational' },
     ]);
   });
 
@@ -139,7 +165,7 @@ describe('status payload normalization', () => {
 
     expect(parsed.overall).toBe('unavailable');
     expect(parsed.components).toEqual([
-      { id: 'website', name: 'Website', state: 'operational' },
+      { id: 'website', name: 'Web services', state: 'operational' },
       { id: 'other-bridgeservice', name: 'Bridge Service', state: 'unavailable' },
     ]);
     expect(parsed.components.map(({ id }) => id)).not.toEqual(expect.arrayContaining([

--- a/src/status/useLocalStatus.js
+++ b/src/status/useLocalStatus.js
@@ -5,6 +5,7 @@ const EMPTY_RESULT = {
   phase: 'loading',
   overall: 'unknown',
   components: [],
+  checks: {},
   generatedAt: null,
   snapshotAgeSeconds: null,
   messages: [],


### PR DESCRIPTION
## Summary
- add a sticky header incident banner for fresh degraded/outage states, including affected services and a direct link to `/status`
- reuse the status-page state palette, pulse indicator, and ambient glow in the homepage live service status block
- rename the user-facing `Website` service to `Web services`
- preserve underlying `/status.json` checks so user-facing descriptions can explain the actual impact behind a degraded service
- collapse TURN into the `Voice & video` service and treat a TURN-only outage as degraded calling rather than a universal calling outage
- add contextual impact copy, including the Matrix/TURN case where messaging remains available but legacy calling may fail in restrictive network conditions
- respect reduced-motion preferences for all repeated status animations

## Status contract behavior
The current GitOps feed exposes MatrixRTC core (`calls`) and TURN (`turn`) separately. This PR keeps that detail internally while presenting one user-facing `Voice & video` service:
- MatrixRTC core down -> Voice & video unavailable
- MatrixRTC core healthy + TURN down -> Voice & video degraded
- the status page explains that Matrix messaging remains available while TURN-assisted/legacy calling may fail under restrictive network conditions

No server-side status contract changes are required.

## Validation
- expanded parser tests for TURN-aware degradation semantics
- expanded status-page tests for contextual incident descriptions and `Web services`
- added header incident-banner tests

Draft for UI review; do not merge yet.