### PR TITLE
Add unlinked /migrate landing page for ColonelKrud migration

### DIFF
--- a/scripts/prerender-routes.mjs
+++ b/scripts/prerender-routes.mjs
@@ -22,7 +22,8 @@ function renderMetadata(pathname, { notFound = false } = {}) {
     .replace(/<meta\s+name=["']description["'][^>]*>/i, `<meta name="description" content="${description}" />`);
 
   const routeTags = [
-    notFound ? `<meta name="robots" content="${escapeHtml(metadata.robots)}" />` : `<link rel="canonical" href="${url}" />`,
+    `<link rel="canonical" href="${url}" />`,
+    ...(metadata.robots ? [`<meta name="robots" content="${escapeHtml(metadata.robots)}" />`] : []),
     '<meta property="og:type" content="website" />',
     `<meta property="og:title" content="${title}" />`,
     `<meta property="og:description" content="${description}" />`,

--- a/src/index.css
+++ b/src/index.css
@@ -219,3 +219,17 @@ header.sticky > div > a[href="/"]:first-child::before {
     opacity: 0.2;
   }
 }
+
+.migration-flow { display: flex; align-items: center; gap: 0.75rem; color: #cffafe; font-weight: 600; }
+.migration-flow__track { position: relative; width: 5rem; height: 1px; background: rgba(103, 232, 249, 0.3); }
+.migration-flow__track::after { position: absolute; right: -1px; top: -3px; width: 7px; height: 7px; content: ""; border-right: 1px solid #67e8f9; border-top: 1px solid #67e8f9; transform: rotate(45deg); }
+.migration-flow__track i { position: absolute; top: -3px; width: 7px; height: 7px; border-radius: 9999px; background: #67e8f9; box-shadow: 0 0 10px #22d3ee; animation: migration-pulse 2.4s linear infinite; }
+@keyframes migration-pulse { from { left: 0; opacity: 0; } 15%, 85% { opacity: 1; } to { left: calc(100% - 7px); opacity: 0; } }
+@media (max-width: 479px) {
+  .migration-flow { flex-direction: column; align-items: flex-start; }
+  .migration-flow__track { width: 1px; height: 2.75rem; margin-left: 0.5rem; }
+  .migration-flow__track::after { right: -3px; top: auto; bottom: 0; transform: rotate(135deg); }
+  .migration-flow__track i { left: -3px; animation-name: migration-pulse-vertical; }
+}
+@keyframes migration-pulse-vertical { from { top: 0; opacity: 0; } 15%, 85% { opacity: 1; } to { top: calc(100% - 7px); opacity: 0; } }
+@media (prefers-reduced-motion: reduce) { .migration-flow__track i { animation: none !important; left: calc(50% - 3px); opacity: 0.7; } }

--- a/src/layout/MigrationLayout.jsx
+++ b/src/layout/MigrationLayout.jsx
@@ -1,0 +1,12 @@
+import { Link } from '../router/Router';
+
+const links = [['Help', '/help'], ['Support', '/support'], ['Terms', '/terms'], ['Rules', '/rules'], ['Privacy', '/privacy']];
+
+export default function MigrationLayout({ children }) {
+  return <div className="min-h-screen overflow-x-hidden bg-slate-950 text-slate-100">
+    <a href="#main-content" className="sr-only z-50 rounded bg-cyan-300 p-3 text-slate-950 focus:not-sr-only focus:fixed focus:left-3 focus:top-3">Skip to content</a>
+    <header className="border-b border-white/10"><div className="mx-auto flex max-w-5xl items-center px-4 py-4 sm:px-6 lg:px-8"><Link to="/" className="font-semibold text-white">CK Conflux</Link><span className="ml-auto text-xs uppercase tracking-[0.16em] text-slate-400">Migration guide</span></div></header>
+    <main id="main-content">{children}</main>
+    <footer className="border-t border-white/10"><nav aria-label="Migration page links" className="mx-auto flex max-w-5xl flex-wrap justify-center gap-x-5 gap-y-2 px-4 py-7 text-sm text-slate-400">{links.map(([label, to]) => <Link key={to} to={to} className="rounded hover:text-white">{label}</Link>)}</nav></footer>
+  </div>;
+}

--- a/src/metadata/pageMetadata.js
+++ b/src/metadata/pageMetadata.js
@@ -3,6 +3,7 @@ const summary = 'Private community chat and secure messaging with Element on Mat
 const descriptions = {
   '/': summary,
   '/about': 'Learn who operates CK Conflux, how Element and Matrix differ from the community, and where to find support, notices, and availability information.',
+  '/migrate': 'Legacy ColonelKrud users can create a new CK Conflux Matrix account with the migration registration code.',
   '/join': 'Learn who can join CK Conflux, how to get a registration token, and how to create and secure your Matrix account.',
   '/why-ck-conflux': 'Learn why CK Conflux offers community communication without platform lock-in.',
   '/matrix': 'Understand Matrix, CK Conflux, Element, federation, rooms, Spaces, and your Matrix ID.',
@@ -17,7 +18,7 @@ const descriptions = {
   '/terms': 'Read the CK Conflux terms of use.',
   '/rules': 'Read the CK Conflux community server rules.',
 };
-const labels = {'/':'Home','/about':'About CK Conflux','/join':'Join CK Conflux','/why-ck-conflux':'Why CK Conflux','/matrix':'Matrix and Element','/calls':'Element Call','/membership':'Membership','/security':'Security','/privacy':'Privacy Policy','/status':'Status','/help':'Help','/support':'Support','/teamspeak':'TeamSpeak 6 Beta','/terms':'Terms of Use','/rules':'Server Rules'};
+const labels = {'/':'Home','/about':'About CK Conflux','/join':'Join CK Conflux','/migrate':'ColonelKrud Migration','/why-ck-conflux':'Why CK Conflux','/matrix':'Matrix and Element','/calls':'Element Call','/membership':'Membership','/security':'Security','/privacy':'Privacy Policy','/status':'Status','/help':'Help','/support':'Support','/teamspeak':'TeamSpeak 6 Beta','/terms':'Terms of Use','/rules':'Server Rules'};
 
 export const ROUTE_PATHS = Object.freeze(Object.keys(labels));
 
@@ -29,6 +30,6 @@ export function getPageMetadata(pathname) {
     description: known ? descriptions[pathname] : 'The requested CK Conflux page could not be found.',
     url: `${SITE_URL}${pathname}`,
     known,
-    robots: known ? null : 'noindex, nofollow',
+    robots: pathname === '/migrate' || !known ? 'noindex, nofollow' : null,
   };
 }

--- a/src/pages/Migrate.jsx
+++ b/src/pages/Migrate.jsx
@@ -1,0 +1,29 @@
+import { useState } from 'react';
+
+export const MIGRATION_TOKEN = 'COLONELKRUD-TO-CONFLUX';
+export const REGISTRATION_URL = 'https://element.ckconflux.com/#/register';
+const steps = ['Copy the migration registration code.', 'Open CK Conflux registration.', 'Choose an available username, enter an email address, and create a password.', 'Enter the migration code when registration asks for a token.', 'Verify the email address.', 'After signing in, configure and save the Matrix encryption recovery key.'];
+
+export default function Migrate() {
+  const [copyState, setCopyState] = useState('idle');
+  const copyToken = async () => {
+    if (!navigator.clipboard?.writeText) { setCopyState('unavailable'); return; }
+    try { await navigator.clipboard.writeText(MIGRATION_TOKEN); setCopyState('copied'); }
+    catch { setCopyState('failed'); }
+  };
+  const feedback = copyState === 'copied' ? 'Migration code copied.' : copyState === 'idle' ? '' : 'Copy unavailable. Select and copy the code manually.';
+
+  return <>
+    <section className="border-b border-white/10 bg-[radial-gradient(circle_at_top,rgba(34,211,238,0.16),transparent_55%)]"><div className="mx-auto grid max-w-5xl gap-10 px-4 py-12 sm:px-6 lg:grid-cols-[1.2fr_0.8fr] lg:px-8 lg:py-20">
+      <div><p className="text-sm font-semibold uppercase tracking-[0.18em] text-cyan-200">Legacy service migration</p><h1 className="mt-3 text-3xl font-semibold tracking-tight text-white sm:text-5xl">ColonelKrud has moved to CK Conflux</h1><p className="mt-5 max-w-2xl text-lg leading-8 text-slate-300">Users of legacy ColonelKrud services can create a new CK Conflux Matrix account using the migration registration code below.</p></div>
+      <div className="migration-flow self-center" aria-hidden="true"><span>colonelkrud.com</span><span className="migration-flow__track"><i /></span><span>ckconflux.com</span></div>
+    </div></section>
+    <section className="mx-auto max-w-5xl px-4 py-10 sm:px-6 lg:px-8" aria-labelledby="code-heading"><div className="rounded-2xl border border-cyan-300/25 bg-cyan-400/[0.07] p-6 sm:p-8">
+      <h2 id="code-heading" className="text-xl font-semibold text-white">Your migration registration code</h2><div className="mt-4 flex flex-col gap-3 sm:flex-row sm:items-center"><code className="min-w-0 select-all overflow-x-auto rounded-xl border border-white/10 bg-slate-950 px-4 py-3 text-base font-semibold text-cyan-200 sm:text-lg">{MIGRATION_TOKEN}</code><button type="button" onClick={copyToken} aria-label="Copy migration registration code" className="rounded-xl border border-white/15 bg-white/10 px-5 py-3 font-semibold text-white hover:bg-white/15">{copyState === 'copied' ? 'Copied!' : 'Copy code'}</button></div>
+      <p className="mt-3 min-h-6 text-sm text-slate-300" role="status" aria-live="polite">{feedback}</p><a href={REGISTRATION_URL} className="mt-3 inline-flex w-full justify-center rounded-xl bg-cyan-400 px-5 py-3 font-semibold text-slate-950 shadow-lg shadow-cyan-500/20 sm:w-auto">Create my CK Conflux account</a>
+    </div></section>
+    <section className="mx-auto grid max-w-5xl gap-8 px-4 pb-12 sm:px-6 lg:grid-cols-[1.3fr_0.7fr] lg:px-8"><div><h2 className="text-2xl font-semibold text-white">Move to CK Conflux in six steps</h2><ol className="mt-5 space-y-3">{steps.map((step, index) => <li key={step} className="flex gap-4 rounded-xl border border-white/10 bg-white/[0.04] p-4"><span aria-hidden="true" className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-cyan-400 font-semibold text-slate-950">{index + 1}</span><p className="pt-0.5 leading-6 text-slate-300">{step}</p></li>)}</ol></div>
+      <div className="space-y-5"><article className="rounded-2xl border border-white/10 bg-white/5 p-6"><h2 className="text-xl font-semibold text-white">Your new Matrix ID</h2><p className="mt-3 leading-7 text-slate-300">Your new identity will look like <code className="select-all rounded bg-slate-900 px-2 py-1 text-cyan-200">@username:ckconflux.com</code>.</p></article><aside className="rounded-2xl border border-amber-300/20 bg-amber-300/[0.06] p-6" aria-labelledby="separate-identities"><h2 id="separate-identities" className="text-xl font-semibold text-white">Separate accounts and history</h2><p className="mt-3 text-sm leading-6 text-slate-300">Your legacy account and new CK Conflux account are separate identities. Creating the new account does not automatically migrate old login sessions, account identity, or encrypted message history.</p></aside></div>
+    </section>
+  </>;
+}

--- a/src/pages/Migrate.test.jsx
+++ b/src/pages/Migrate.test.jsx
@@ -1,0 +1,44 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import App from '../App';
+import { getPageMetadata, ROUTE_PATHS } from '../metadata/pageMetadata';
+
+const renderMigration = (path = '/migrate') => { window.history.pushState({}, '', path); return render(<App />); };
+afterEach(() => { vi.unstubAllGlobals(); document.head.querySelectorAll('link[rel="canonical"], meta[name="robots"]').forEach((node) => node.remove()); });
+
+describe('legacy migration campaign', () => {
+  it('resolves the unlinked route and presents its registration details', async () => {
+    renderMigration('/migrate?from=matrix');
+    expect(screen.getByRole('heading', { level: 1, name: 'ColonelKrud has moved to CK Conflux' })).toBeInTheDocument();
+    expect(screen.getByText('COLONELKRUD-TO-CONFLUX')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Create my CK Conflux account' })).toHaveAttribute('href', 'https://element.ckconflux.com/#/register');
+    expect(window.location.search).toBe('?from=matrix');
+    expect(screen.queryByRole('navigation', { name: 'Primary navigation' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('navigation', { name: 'Explore links' })).not.toBeInTheDocument();
+    await waitFor(() => expect(document.querySelector('meta[name="robots"]')).toHaveAttribute('content', 'noindex, nofollow'));
+  });
+
+  it('copies the campaign token with accessible confirmation', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    vi.stubGlobal('navigator', { ...navigator, clipboard: { writeText } });
+    renderMigration();
+    fireEvent.click(screen.getByRole('button', { name: 'Copy migration registration code' }));
+    await waitFor(() => expect(writeText).toHaveBeenCalledWith('COLONELKRUD-TO-CONFLUX'));
+    expect(await screen.findByText('Migration code copied.')).toBeInTheDocument();
+  });
+
+  it('keeps the code readable when clipboard support is unavailable', async () => {
+    vi.stubGlobal('navigator', { ...navigator, clipboard: undefined });
+    renderMigration();
+    fireEvent.click(screen.getByRole('button', { name: 'Copy migration registration code' }));
+    expect(await screen.findByText(/Select and copy the code manually/)).toBeInTheDocument();
+    expect(screen.getByText('COLONELKRUD-TO-CONFLUX')).toBeInTheDocument();
+  });
+
+  it('declares migrate as prerenderable while normal known routes stay indexable', () => {
+    expect(ROUTE_PATHS).toContain('/migrate');
+    expect(getPageMetadata('/migrate').robots).toBe('noindex, nofollow');
+    expect(getPageMetadata('/join').robots).toBeNull();
+    expect(getPageMetadata('/').robots).toBeNull();
+  });
+});

--- a/src/router/AppRouter.jsx
+++ b/src/router/AppRouter.jsx
@@ -17,9 +17,11 @@ import Support from '../pages/Support';
 import Membership from '../pages/Membership';
 import Join from '../pages/Join';
 import About from '../pages/About';
+import Migrate from '../pages/Migrate';
+import MigrationLayout from '../layout/MigrationLayout';
 import { useRouter } from './Router';
 
-const routes = {'/': <Home />, '/about': <About />, '/join': <Join />, '/why-ck-conflux': <WhyCKConflux />, '/matrix': <Matrix />, '/calls': <Calls />, '/membership': <Membership />, '/teamspeak': <TeamSpeak />, '/security': <Security />, '/help': <Help />, '/support': <Support />, '/status': <Status />, '/privacy': <Privacy />, '/terms': <Terms />, '/rules': <Rules />};
+const routes = {'/': <Home />, '/about': <About />, '/join': <Join />, '/migrate': <Migrate />, '/why-ck-conflux': <WhyCKConflux />, '/matrix': <Matrix />, '/calls': <Calls />, '/membership': <Membership />, '/teamspeak': <TeamSpeak />, '/security': <Security />, '/help': <Help />, '/support': <Support />, '/status': <Status />, '/privacy': <Privacy />, '/terms': <Terms />, '/rules': <Rules />};
 
 export default function AppRouter() {
   const { pathname, navigationKey } = useRouter();
@@ -29,5 +31,6 @@ export default function AppRouter() {
     const heading = document.querySelector('#main-content h1');
     if (heading) { heading.setAttribute('tabindex', '-1'); heading.focus(); }
   }, [navigationKey]);
-  return <><Metadata pathname={pathname} /><SiteLayout>{page}</SiteLayout></>;
+  const Layout = pathname === '/migrate' ? MigrationLayout : SiteLayout;
+  return <><Metadata pathname={pathname} /><Layout>{page}</Layout></>;
 }


### PR DESCRIPTION
### Motivation
- Provide an unlinked campaign landing page at `/migrate` for legacy `colonelkrud.com` users to register at CK Conflux using a migration token without modifying infrastructure or normal site navigation.
- Keep the page visually and functionally native to the existing CK Conflux site (styling, accessibility, reduced-motion) and ensure the registration flow still directs users to Element for account creation.
- Ensure the route is prerendered but explicitly marked `noindex, nofollow` so it is discoverable by announcements while not being indexed by search engines.

### Description
- Added a dedicated migration page component and constants: `src/pages/Migrate.jsx` defines `MIGRATION_TOKEN = 'COLONELKRUD-TO-CONFLUX'` and `REGISTRATION_URL = 'https://element.ckconflux.com/#/register'`, renders hero, readable token, accessible copy button with Clipboard API success/failure handling and an aria-live status message, the primary external CTA, onboarding steps, identity note, and migration warning.
- Added a minimal campaign layout: `src/layout/MigrationLayout.jsx` that omits normal site navigation and exposes only skip-to-content plus small help/support/legal links at the bottom.
- Registered the route and enabled route-aware layout selection: `src/router/AppRouter.jsx` includes `/migrate` and uses `MigrationLayout` when `pathname === '/migrate'` so the page remains unlinked from main header/footer navigation.
- Made `/migrate` a known prerendered route and explicitly mark it noindex: `src/metadata/pageMetadata.js` adds descriptions/labels for `/migrate` and returns `robots: 'noindex, nofollow'` for that route while preserving indexability of normal known routes.
- Updated prerendering to include optional robots meta tags: `scripts/prerender-routes.mjs` now emits a canonical link and conditionally emits a `meta[name="robots"]` tag when `getPageMetadata` provides one so generated `dist/migrate.html` contains the robots directive.
- Added a lightweight CSS migration visual and reduced-motion support: `src/index.css` includes `.migration-flow` styles and a subtle CSS animation which collapses vertically on narrow screens and is suppressed under `prefers-reduced-motion`.
- Added focused tests: `src/pages/Migrate.test.jsx` validates the route renders, token is present, CTA points at Element registration, the route is not present in normal nav, copy-to-clipboard works with Clipboard API, fallback behaves when Clipboard API is missing, and metadata reports `noindex, nofollow` while normal routes remain indexable.
- Files added/modified: `src/pages/Migrate.jsx`, `src/layout/MigrationLayout.jsx`, `src/pages/Migrate.test.jsx`, `src/index.css` (CSS additions), `src/router/AppRouter.jsx`, `src/metadata/pageMetadata.js`, `scripts/prerender-routes.mjs`.

### Testing
- Ran lint: `npm run lint` — completed with zero errors and one existing Fast Refresh warning (pre-existing) in `src/components/StatusStateVisual.jsx`.
- Unit tests: `npm run test:run` — all tests passed (reported: 9 test files, 123 tests; all passed), including the new `/migrate` tests.
- Production build & prerender: `npm run build` — Vite build succeeded and `scripts/prerender-routes.mjs` generated prerendered HTML files; `dist/migrate.html` was produced.
- Verified generated `dist/migrate.html` contains the expected metadata: correct title/description, canonical `https://ckconflux.com/migrate`, and `meta name="robots" content="noindex, nofollow"`.
- Confirmed normal known routes (e.g. `/join`) remain indexable (no `robots` meta emitted for them in prerender output).
- `./scripts/validate-nginx.sh` could not run due to Docker not being available in this environment; `./scripts/validate-helm.sh` could not run because Helm was not available; no Helm/nginx config files were changed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a966aef4de4832cb46dc984d95f0bb7)