### PR TITLE
Integrate resilient live Foundry status

### DIFF
--- a/src/components/FoundryServerCard.jsx
+++ b/src/components/FoundryServerCard.jsx
@@ -1,6 +1,7 @@
 import { CalendarDays, ExternalLink as ExternalLinkIcon, Server } from 'lucide-react';
 import { ExternalLink } from './SiteLink';
 import { FOUNDRY_STATUS } from '../foundry/foundryStatus';
+import { usePrefersReducedMotion } from '../hooks/usePrefersReducedMotion';
 
 const statusStyles = {
   checking: 'border-slate-400/30 bg-slate-400/10 text-slate-200',
@@ -11,11 +12,13 @@ const statusStyles = {
 
 export default function FoundryServerCard({ server, status = 'unknown' }) {
   const statusCopy = FOUNDRY_STATUS[status] ?? FOUNDRY_STATUS.unknown;
+  const prefersReducedMotion = usePrefersReducedMotion();
+  const checkingMotion = status === 'checking' && !prefersReducedMotion ? 'animate-pulse' : '';
   return <article className="group flex h-full flex-col rounded-3xl border border-white/10 bg-slate-900/70 p-6 shadow-2xl shadow-slate-950/20 backdrop-blur sm:p-8">
     <div className="flex items-start justify-between gap-4">
       <span className="rounded-2xl border border-cyan-300/20 bg-cyan-300/10 p-3 text-cyan-200" aria-hidden="true"><Server size={24} /></span>
       <div role="status" aria-live="polite" className={`rounded-full border px-3 py-1.5 text-sm font-semibold ${statusStyles[status] ?? statusStyles.unknown}`}>
-        <span className="mr-2" aria-hidden="true">●</span>{statusCopy.label}
+        <span className={`mr-2 inline-block ${checkingMotion}`} data-status-indicator={status} aria-hidden="true">●</span>{statusCopy.label}
       </div>
     </div>
     <p className="mt-7 text-xs font-semibold uppercase tracking-[0.18em] text-cyan-200">{server.id}</p>

--- a/src/config/foundry.js
+++ b/src/config/foundry.js
@@ -1,4 +1,6 @@
 export const FOUNDRY_STATUS_ENDPOINT = '/foundry-status.json';
+export const FOUNDRY_STATUS_POLL_INTERVAL_MS = 45_000;
+export const FOUNDRY_STATUS_TIMEOUT_MS = 8_000;
 
 export const FOUNDRY_SERVERS = Object.freeze([
   Object.freeze({

--- a/src/config/foundry.test.js
+++ b/src/config/foundry.test.js
@@ -1,9 +1,16 @@
 import { describe, expect, it } from 'vitest';
-import { FOUNDRY_SERVERS, FOUNDRY_STATUS_ENDPOINT } from './foundry';
+import {
+  FOUNDRY_SERVERS,
+  FOUNDRY_STATUS_ENDPOINT,
+  FOUNDRY_STATUS_POLL_INTERVAL_MS,
+  FOUNDRY_STATUS_TIMEOUT_MS,
+} from './foundry';
 
 describe('Foundry configuration', () => {
   it('keeps stable destinations, schedules, and status endpoint together', () => {
     expect(FOUNDRY_STATUS_ENDPOINT).toBe('/foundry-status.json');
+    expect(FOUNDRY_STATUS_POLL_INTERVAL_MS).toBe(45_000);
+    expect(FOUNDRY_STATUS_TIMEOUT_MS).toBe(8_000);
     expect(FOUNDRY_SERVERS).toEqual([
       expect.objectContaining({ id: 'fvtt1', url: 'https://fvtt1.ckconflux.com', schedule: { day: 'Wednesday', time: '6:30 PM Eastern' } }),
       expect.objectContaining({ id: 'fvtt2', url: 'https://fvtt2.ckconflux.com', schedule: { day: 'Thursday', time: '6:30 PM Eastern' } }),

--- a/src/foundry/foundryStatus.test.js
+++ b/src/foundry/foundryStatus.test.js
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { parseFoundryStatus } from './foundryStatus';
+import { parseStatus } from '../status/status';
 
 const payload = (servers, extra = {}) => ({ generated_at: '2026-09-02T20:30:00Z', stale: false, servers, ...extra });
 
@@ -23,5 +24,11 @@ describe('Foundry status contract', () => {
 
   it('maps missing servers and future status values to unknown', () => {
     expect(parseFoundryStatus(payload({ fvtt1: { status: 'maintenance' } }))).toEqual({ fvtt1: 'unknown', fvtt2: 'unknown' });
+  });
+
+  it('does not feed the Foundry contract into global status or incident severity', () => {
+    const foundryPayload = payload({ fvtt1: { status: 'down' }, fvtt2: { status: 'up' } });
+    expect(parseFoundryStatus(foundryPayload)).toEqual({ fvtt1: 'offline', fvtt2: 'online' });
+    expect(parseStatus(foundryPayload)).toBeNull();
   });
 });

--- a/src/foundry/useFoundryStatus.js
+++ b/src/foundry/useFoundryStatus.js
@@ -1,34 +1,59 @@
-import { useEffect, useState } from 'react';
-import { FOUNDRY_SERVERS, FOUNDRY_STATUS_ENDPOINT } from '../config/foundry';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import {
+  FOUNDRY_SERVERS,
+  FOUNDRY_STATUS_ENDPOINT,
+  FOUNDRY_STATUS_POLL_INTERVAL_MS,
+  FOUNDRY_STATUS_TIMEOUT_MS,
+} from '../config/foundry';
 import { parseFoundryStatus } from './foundryStatus';
 
 const initialStatuses = Object.freeze(Object.fromEntries(FOUNDRY_SERVERS.map(({ id }) => [id, 'checking'])));
 const unavailableStatuses = Object.freeze(Object.fromEntries(FOUNDRY_SERVERS.map(({ id }) => [id, 'unknown'])));
 
-export function useFoundryStatus({ timeoutMs = 8000 } = {}) {
+export function useFoundryStatus({
+  pollIntervalMs = FOUNDRY_STATUS_POLL_INTERVAL_MS,
+  timeoutMs = FOUNDRY_STATUS_TIMEOUT_MS,
+} = {}) {
   const [statuses, setStatuses] = useState(initialStatuses);
+  const mounted = useRef(false);
+  const activeController = useRef(null);
+
+  const refresh = useCallback(async () => {
+    // Aborting first makes an explicit refresh safe even if a previous request hung.
+    activeController.current?.abort();
+    const controller = new AbortController();
+    activeController.current = controller;
+    const timeout = setTimeout(() => controller.abort(), timeoutMs);
+    try {
+      const response = await fetch(FOUNDRY_STATUS_ENDPOINT, {
+        signal: controller.signal,
+        headers: { Accept: 'application/json' },
+      });
+      if (!response.ok) throw new Error(`Foundry status request failed (${response.status})`);
+      const parsed = parseFoundryStatus(await response.json());
+      if (mounted.current && activeController.current === controller) setStatuses(parsed);
+    } catch {
+      if (mounted.current && activeController.current === controller) {
+        // Health is advisory: failed monitoring is unknown, never an inferred outage.
+        setStatuses(unavailableStatuses);
+      }
+    } finally {
+      clearTimeout(timeout);
+      if (activeController.current === controller) activeController.current = null;
+    }
+  }, [timeoutMs]);
 
   useEffect(() => {
-    const controller = new AbortController();
-    const timeout = setTimeout(() => controller.abort(), timeoutMs);
-    let active = true;
-    async function checkStatus() {
-      try {
-        const response = await fetch(FOUNDRY_STATUS_ENDPOINT, {
-          signal: controller.signal,
-          headers: { Accept: 'application/json' },
-        });
-        const payload = await response.json();
-        if (active) setStatuses(parseFoundryStatus(payload));
-      } catch {
-        if (active) setStatuses(unavailableStatuses);
-      } finally {
-        clearTimeout(timeout);
-      }
-    }
-    checkStatus();
-    return () => { active = false; controller.abort(); clearTimeout(timeout); };
-  }, [timeoutMs]);
+    mounted.current = true;
+    refresh();
+    const interval = pollIntervalMs > 0 ? setInterval(refresh, pollIntervalMs) : null;
+    return () => {
+      mounted.current = false;
+      activeController.current?.abort();
+      activeController.current = null;
+      if (interval) clearInterval(interval);
+    };
+  }, [pollIntervalMs, refresh]);
 
   return statuses;
 }

--- a/src/foundry/useFoundryStatus.test.jsx
+++ b/src/foundry/useFoundryStatus.test.jsx
@@ -1,38 +1,123 @@
 import { act, renderHook, waitFor } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
+import { FOUNDRY_STATUS_POLL_INTERVAL_MS, FOUNDRY_STATUS_TIMEOUT_MS } from '../config/foundry';
 import { useFoundryStatus } from './useFoundryStatus';
+
+const snapshot = (fvtt1 = 'up', fvtt2 = 'down') => ({
+  generated_at: '2026-09-02T20:30:00Z',
+  stale: false,
+  servers: { fvtt1: { status: fvtt1 }, fvtt2: { status: fvtt2 } },
+});
+const response = (body, overrides = {}) => ({ ok: true, status: 200, json: async () => body, ...overrides });
+const deferred = () => {
+  let resolve;
+  let reject;
+  const promise = new Promise((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+};
+
+const flush = async () => { await act(async () => { await Promise.resolve(); await Promise.resolve(); }); };
 
 afterEach(() => {
   vi.useRealTimers();
+  vi.restoreAllMocks();
   vi.unstubAllGlobals();
 });
 
 describe('useFoundryStatus', () => {
-  it('uses its own endpoint and parses the initial request', async () => {
-    const fetch = vi.fn().mockResolvedValue({ json: async () => ({ stale: false, servers: { fvtt1: { status: 'up' }, fvtt2: { status: 'down' } } }) });
+  it('starts at Checking, uses only its same-origin endpoint, and maps up/down independently', async () => {
+    const request = deferred();
+    const fetch = vi.fn().mockReturnValue(request.promise);
     vi.stubGlobal('fetch', fetch);
-    const { result } = renderHook(() => useFoundryStatus());
+    const { result } = renderHook(() => useFoundryStatus({ pollIntervalMs: 0 }));
+
     expect(result.current).toEqual({ fvtt1: 'checking', fvtt2: 'checking' });
+    request.resolve(response(snapshot()));
     await waitFor(() => expect(result.current).toEqual({ fvtt1: 'online', fvtt2: 'offline' }));
-    expect(fetch).toHaveBeenCalledOnce();
-    expect(fetch).toHaveBeenCalledWith('/foundry-status.json', expect.any(Object));
+    expect(fetch).toHaveBeenCalledWith('/foundry-status.json', expect.objectContaining({ signal: expect.any(AbortSignal) }));
     expect(fetch).not.toHaveBeenCalledWith('/status.json', expect.anything());
+    expect(fetch.mock.calls.flat().join(' ')).not.toMatch(/fvtt[12]\.ckconflux\.com/);
   });
 
-  it('turns fetch and JSON failures into advisory unknown status', async () => {
-    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new TypeError('offline')));
-    const { result } = renderHook(() => useFoundryStatus());
+  it.each([
+    ['request rejection', () => Promise.reject(new TypeError('network unavailable'))],
+    ['HTTP failure', () => Promise.resolve(response({}, { ok: false, status: 503 }))],
+    ['malformed JSON', () => Promise.resolve(response(null))],
+  ])('turns %s into advisory Unknown, never Offline', async (_label, implementation) => {
+    vi.stubGlobal('fetch', vi.fn(implementation));
+    const { result } = renderHook(() => useFoundryStatus({ pollIntervalMs: 0 }));
     await waitFor(() => expect(result.current).toEqual({ fvtt1: 'unknown', fvtt2: 'unknown' }));
   });
 
-  it('turns a hung status request into advisory unknown status after the timeout', async () => {
+  it('turns a hung request into Unknown after the bounded timeout', async () => {
     vi.useFakeTimers();
-    vi.stubGlobal('fetch', vi.fn((_url, { signal }) => new Promise((_resolve, reject) => {
+    const fetch = vi.fn((_url, { signal }) => new Promise((_resolve, reject) => {
       signal.addEventListener('abort', () => reject(new DOMException('Aborted', 'AbortError')));
-    })));
-    const { result } = renderHook(() => useFoundryStatus({ timeoutMs: 50 }));
+    }));
+    vi.stubGlobal('fetch', fetch);
+    const { result } = renderHook(() => useFoundryStatus({ pollIntervalMs: 0, timeoutMs: 50 }));
+
     expect(result.current).toEqual({ fvtt1: 'checking', fvtt2: 'checking' });
     await act(async () => { await vi.advanceTimersByTimeAsync(51); });
+    expect(fetch.mock.calls[0][1].signal.aborted).toBe(true);
     expect(result.current).toEqual({ fvtt1: 'unknown', fvtt2: 'unknown' });
+  });
+
+  it('polls every 45 seconds, exposes a failed refresh as Unknown, and recovers later', async () => {
+    vi.useFakeTimers();
+    const fetch = vi.fn()
+      .mockResolvedValueOnce(response(snapshot('up', 'up')))
+      .mockRejectedValueOnce(new Error('temporary monitoring failure'))
+      .mockResolvedValueOnce(response(snapshot('down', 'up')));
+    vi.stubGlobal('fetch', fetch);
+    const { result } = renderHook(() => useFoundryStatus());
+
+    await flush();
+    expect(result.current).toEqual({ fvtt1: 'online', fvtt2: 'online' });
+    await act(async () => { await vi.advanceTimersByTimeAsync(FOUNDRY_STATUS_POLL_INTERVAL_MS); });
+    expect(result.current).toEqual({ fvtt1: 'unknown', fvtt2: 'unknown' });
+    await act(async () => { await vi.advanceTimersByTimeAsync(FOUNDRY_STATUS_POLL_INTERVAL_MS); });
+    expect(result.current).toEqual({ fvtt1: 'offline', fvtt2: 'online' });
+    expect(fetch).toHaveBeenCalledTimes(3);
+    expect(FOUNDRY_STATUS_TIMEOUT_MS).toBeLessThan(FOUNDRY_STATUS_POLL_INTERVAL_MS);
+  });
+
+  it('aborts an old request and prevents its late result from racing a newer poll', async () => {
+    vi.useFakeTimers();
+    const first = deferred();
+    const fetch = vi.fn()
+      .mockReturnValueOnce(first.promise)
+      .mockResolvedValueOnce(response(snapshot('down', 'up')));
+    vi.stubGlobal('fetch', fetch);
+    const { result } = renderHook(() => useFoundryStatus({ pollIntervalMs: 100, timeoutMs: 1_000 }));
+    const firstSignal = fetch.mock.calls[0][1].signal;
+
+    await act(async () => { await vi.advanceTimersByTimeAsync(100); });
+    expect(firstSignal.aborted).toBe(true);
+    expect(result.current).toEqual({ fvtt1: 'offline', fvtt2: 'online' });
+
+    first.resolve(response(snapshot('up', 'down')));
+    await flush();
+    expect(result.current).toEqual({ fvtt1: 'offline', fvtt2: 'online' });
+  });
+
+  it('aborts the active request and clears timeout and polling timers on unmount', () => {
+    vi.useFakeTimers();
+    const clearInterval = vi.spyOn(globalThis, 'clearInterval');
+    let signal;
+    vi.stubGlobal('fetch', vi.fn((_url, options) => {
+      signal = options.signal;
+      return new Promise(() => {});
+    }));
+    const { unmount } = renderHook(() => useFoundryStatus({ pollIntervalMs: 100, timeoutMs: 1_000 }));
+
+    unmount();
+    expect(signal.aborted).toBe(true);
+    expect(clearInterval).toHaveBeenCalled();
+    act(() => { vi.advanceTimersByTime(2_000); });
+    expect(fetch).toHaveBeenCalledOnce();
   });
 });

--- a/src/pages/Foundry.test.jsx
+++ b/src/pages/Foundry.test.jsx
@@ -32,6 +32,21 @@ describe('Foundry landing page', () => {
     }
   });
 
+  it('uses lightweight Checking motion only when reduced motion is not requested', async () => {
+    const matchMedia = vi.fn().mockReturnValue({
+      matches: true,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    });
+    vi.stubGlobal('matchMedia', matchMedia);
+    render(<FoundryServerCard server={FOUNDRY_SERVERS[0]} status="checking" />);
+
+    const indicator = document.querySelector('[data-status-indicator="checking"]');
+    await waitFor(() => expect(indicator).not.toHaveClass('animate-pulse'));
+    expect(matchMedia).toHaveBeenCalledWith('(prefers-reduced-motion: reduce)');
+    expect(screen.getByRole('status')).toHaveTextContent('Checking');
+  });
+
   it('uses canonical voluntary-support messaging and footer discoverability', () => {
     vi.stubGlobal('fetch', vi.fn(() => new Promise(() => {})));
     renderFoundry();


### PR DESCRIPTION
### Motivation
- Provide a dedicated, resilient same-origin Foundry status client so the Foundry landing page shows live advisory health without affecting global site status semantics.
- Ensure the production user journey is validated and hardened with bounded requests, polling, abort/cleanup semantics, and no request races.
- Keep the Foundry health UI visually subtle, accessible, and respectful of `prefers-reduced-motion` while keeping server entry links actionable in all states.
- Add deterministic automated tests covering positive, negative, timeout, polling, recovery, unmount/abort, and isolation scenarios.

### Description
- Implemented a centralized Foundry polling client in `src/foundry/useFoundryStatus.js` using `AbortController`, request timeouts, a single shared interval, mounted guards, and prevention of overlapping/racing requests, exposing the hook `useFoundryStatus`.
- Added configuration constants `FOUNDRY_STATUS_POLL_INTERVAL_MS = 45_000` and `FOUNDRY_STATUS_TIMEOUT_MS = 8_000` in `src/config/foundry.js` and used those defaults in the hook to enforce a 45s poll and 8s request timeout.
- Kept state semantics per contract: initial `Checking`, `Online` only for fresh `up`, `Offline` only for fresh `down`, and `Unknown/Status unavailable` for failures, timeouts, stale/malformed payloads, missing servers, or unrecognized values; ensured Foundry never drives global `/status.json` parsing or site-wide incident severity.
- UX improvements: added reduced-motion-aware lightweight Checking motion in `src/components/FoundryServerCard.jsx`, preserved visible status text, and ensured `Enter Server` external links remain actionable in every state.
- Tests and regressions: added and expanded tests in `src/foundry/useFoundryStatus.test.jsx`, `src/foundry/foundryStatus.test.js`, and `src/pages/Foundry.test.jsx` to cover initial Checking, Online/Offline mapping, request failures, timeout behavior, polling, recovery after transient failures, abort/race prevention, unmount cleanup, reduced-motion behavior, server mapping, and isolation from global status parsing.
- References recorded in PR metadata: closes `#72`, parent `#70`, completed dependency `#71`, and backend dependency `colonelkrud/ck-conflux-apps-gitops#479` (these are documented in the branch/PR message).

### Testing
- Ran the deterministic unit/integration suite with `npm test -- --run`, and the targeted tests plus full Vitest suite passed (all tests green in this environment).
- Built the production bundle with `npm run build`, which completed successfully, and ran `npm run lint` which passed with one pre-existing Fast Refresh warning unrelated to this change.
- Attempted live production validation against `https://ckconflux.com/foundry-status.json`, `https://ckconflux.com/foundry`, and the `fvtt1/fvtt2` hosts, but outbound requests from this execution environment were blocked (HTTP 403 via proxy), so live payload/desktop/mobile screenshots and remote reachability checks could not be independently retrieved here; the code is implemented to use same-origin `GET /foundry-status.json` as required.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a9a22474220832c9e95bb6468716d47)