### PR TITLE
Add daily maintenance notice to /status page

### DIFF
--- a/src/pages/Status.jsx
+++ b/src/pages/Status.jsx
@@ -1,5 +1,5 @@
 import { motion as Motion } from 'framer-motion';
-import { RefreshCw } from 'lucide-react';
+import { Clock3, RefreshCw } from 'lucide-react';
 import { ExternalLink } from '../components/SiteLink';
 import {
   StatusAmbientGlow,
@@ -51,6 +51,28 @@ function StateCount({ state, count }) {
     <span aria-hidden="true" className={`h-1.5 w-1.5 rounded-full ${meta.bar}`} />
     {count} {stateLabel(state).toLowerCase()}
   </span>;
+}
+
+function MaintenanceNotice() {
+  return <section className="mt-10 rounded-2xl border border-cyan-200/20 bg-white/[0.04] p-5 sm:p-6" aria-labelledby="maintenance-window">
+    <div className="flex items-start gap-4">
+      <div className="rounded-xl border border-cyan-200/20 bg-cyan-300/[0.07] p-2.5 text-cyan-200">
+        <Clock3 aria-hidden="true" size={20} />
+      </div>
+      <div className="min-w-0 flex-1">
+        <h2 id="maintenance-window" className="text-xl font-semibold text-white">Daily maintenance window</h2>
+        <dl className="mt-4 grid gap-3 sm:grid-cols-3">
+          <div><dt className="text-xs font-semibold uppercase tracking-[0.12em] text-slate-400">Window start</dt><dd className="mt-1 font-semibold text-cyan-100">6:00 AM UTC</dd></div>
+          <div><dt className="text-xs font-semibold uppercase tracking-[0.12em] text-slate-400">Window duration</dt><dd className="mt-1 font-semibold text-cyan-100">4 hours</dd></div>
+          <div><dt className="text-xs font-semibold uppercase tracking-[0.12em] text-slate-400">Frequency</dt><dd className="mt-1 font-semibold text-cyan-100">Daily</dd></div>
+        </dl>
+        <div className="mt-5 space-y-2 border-t border-white/10 pt-4 text-sm leading-6 text-slate-300 sm:text-base">
+          <p>Maintenance usually lasts under 10 minutes, and most applications do not experience any downtime.</p>
+          <p>Some real-time services, such as voice calling and screen sharing, may disconnect briefly while you are moved to another server.</p>
+        </div>
+      </div>
+    </div>
+  </section>;
 }
 
 export default function Status() {
@@ -117,6 +139,8 @@ export default function Status() {
         </Motion.li>;
       })}</ul>
     </section>}
+
+    <MaintenanceNotice />
 
     <div className="mt-10 border-t border-white/10 pt-6"><ExternalLink href={INDEPENDENT_STATUS_URL} target="_blank" rel="noopener noreferrer" className="inline-flex text-sm font-semibold text-cyan-200 hover:text-cyan-100">View uptime history ↗ <span className="sr-only">(opens in a new tab)</span></ExternalLink></div>
   </div>;

--- a/src/pages/Status.test.jsx
+++ b/src/pages/Status.test.jsx
@@ -1,4 +1,4 @@
-import { cleanup, render, screen } from '@testing-library/react';
+import { cleanup, render, screen, within } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import Status from './Status';
 
@@ -10,6 +10,23 @@ afterEach(() => {
 });
 
 describe('Status page', () => {
+  it('shows the daily maintenance guidance between services and uptime history', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(response({ checks: { website: 'ok' } })));
+    render(<Status />);
+
+    const services = await screen.findByRole('heading', { name: 'Services' });
+    const maintenance = screen.getByRole('region', { name: 'Daily maintenance window' });
+    const uptimeHistory = screen.getByRole('link', { name: /View uptime history/ });
+
+    expect(within(maintenance).getByText('6:00 AM UTC')).toBeInTheDocument();
+    expect(within(maintenance).getByText('4 hours')).toBeInTheDocument();
+    expect(within(maintenance).getByText('Daily')).toBeInTheDocument();
+    expect(within(maintenance).getByText(/Maintenance usually lasts under 10 minutes/)).toHaveTextContent('most applications do not experience any downtime');
+    expect(within(maintenance).getByText(/voice calling and screen sharing/)).toHaveTextContent('may disconnect briefly');
+    expect(services.compareDocumentPosition(maintenance) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    expect(maintenance.compareDocumentPosition(uptimeHistory) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+
   it('renders a production-style HTTP 503 outage while preserving all six component states', async () => {
     vi.stubGlobal('fetch', vi.fn().mockResolvedValue(response({
       status: 'down',
@@ -139,6 +156,8 @@ describe('Status page', () => {
     expect(screen.getByText('Current service status is not available yet.')).toBeInTheDocument();
     expect(screen.queryByRole('heading', { name: 'Services' })).not.toBeInTheDocument();
     expect(screen.getByText('A status snapshot is not available yet.')).toBeInTheDocument();
+    expect(screen.getByRole('region', { name: 'Daily maintenance window' })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /View uptime history/ })).toBeInTheDocument();
   });
 
   it('uses neutral incomplete wording when only the feed-level state is unknown', async () => {


### PR DESCRIPTION
### Motivation

- Provide persistent, informational guidance about the CK Conflux daily maintenance window on the Status page so users can understand expected maintenance timing without treating it as an incident. 
- The notice must appear after the Services section (if present) and before the existing uptime history link and remain visible even when no services are rendered.

### Description

- Added a small page-local `MaintenanceNotice` component to `src/pages/Status.jsx` that uses a decorative `Clock3` icon and matches the existing card styling (`rounded-2xl`, subtle cyan border, dark translucent background, slate typography, cyan accents). 
- Rendered `MaintenanceNotice` immediately after the conditional Services section and immediately before the uptime history link so ordering is Services → Maintenance → Uptime history (or Maintenance → Uptime history when Services are absent). 
- Kept the content and accessibility structure semantic (`<section aria-labelledby=

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a9d8e04d108832c88bffefa6c872c2b)